### PR TITLE
fix critical deployment bugs that broke Docker installs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,7 @@ MEILI_MASTER_KEY=your-secure-master-key-here
 
 # Database Configuration
 # SQLite database will be stored at /app/data/onesearch.db inside the container
-DATABASE_URL=sqlite:///data/onesearch.db
+DATABASE_URL=sqlite:////app/data/onesearch.db
 
 # Meilisearch URL (internal Docker network)
 MEILI_URL=http://meilisearch:7700

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to OneSearch will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.1] - 2026-02-07
+
+Hotfix for critical deployment bugs found during first real Proxmox CT install. The app basically couldn't start in Docker.
+
+### Fixed
+
+- **SQLite URL path format** — default DATABASE_URL used 3 slashes (relative path) instead of 4 (absolute path), so SQLAlchemy couldn't find `/data/onesearch.db`. Fixed everywhere: config.py, docker-compose.yml, .env.example, docs. Also fixed the path itself from `/data/` to `/app/data/` to match the Dockerfile. (#69)
+
+- **Alembic hardcoded database path** — alembic.ini had a hardcoded `sqlalchemy.url` that could conflict with the DATABASE_URL env var. Removed it — env.py already sets the URL programmatically from app settings. (#68)
+
+- **APScheduler pickle crash when adding sources** — the SQLAlchemy job store tried to pickle scheduled jobs, but bound methods referencing the engine can't be pickled. Switched to in-memory job store since `_sync_all_jobs` already rebuilds everything from the Source table on startup. (#70)
+
+### Issues Closed
+
+- #68, #69, #70
+
+---
+
 ## [0.7.0] - 2026-02-05
 
 Phase 1 complete. All core features are in — search, indexing, auth, scheduling, document preview.
@@ -13,7 +31,7 @@ Phase 1 complete. All core features are in — search, indexing, auth, schedulin
 
 - **Basic Authentication** - JWT-based auth with setup wizard, login page, protected routes, rate limiting. Config: `SESSION_SECRET`, `SESSION_EXPIRE_HOURS`, `AUTH_RATE_LIMIT`.
 
-- **Scheduled Indexing** - APScheduler-based background indexing with per-source cron schedules. Presets (@hourly, @daily, @weekly) or custom cron expressions. Jobs persist across restarts via SQLAlchemy job store. Per-source locking prevents concurrent indexing (409 on conflict). Config: `SCHEDULER_ENABLED`, `SCHEDULE_TIMEZONE`.
+- **Scheduled Indexing** - APScheduler-based background indexing with per-source cron schedules. Presets (@hourly, @daily, @weekly) or custom cron expressions. Per-source locking prevents concurrent indexing (409 on conflict). Config: `SCHEDULER_ENABLED`, `SCHEDULE_TIMEZONE`.
   - Schedule picker in source add/edit form
   - Schedule column and next scan time in sources table
   - Next scan info on status page
@@ -228,6 +246,7 @@ Phase 1 complete. All core features are in — search, indexing, auth, schedulin
 
 ---
 
+[0.7.1]: https://github.com/demigodmode/OneSearch/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/demigodmode/OneSearch/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/demigodmode/OneSearch/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/demigodmode/OneSearch/compare/v0.4.0...v0.5.0

--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -57,7 +57,7 @@ version_path_separator = os  # Use os.pathsep. Default configuration used for ne
 # are written from script.py.mako
 # output_encoding = utf-8
 
-sqlalchemy.url = sqlite:///data/onesearch.db
+# sqlalchemy.url is set programmatically in env.py from DATABASE_URL
 
 
 [post_write_hooks]

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -18,7 +18,7 @@ class Settings(BaseSettings):
 
     # Database configuration
     database_url: str = Field(
-        default="sqlite:///data/onesearch.db",
+        default="sqlite:////app/data/onesearch.db",
         env="DATABASE_URL"
     )
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onesearch-backend"
-version = "0.7.0"
+version = "0.7.1"
 description = "OneSearch backend API server"
 license = {text = "AGPL-3.0-only"}
 requires-python = ">=3.10"

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onesearch-cli"
-version = "0.7.0"
+version = "0.7.1"
 description = "CLI for OneSearch - Self-hosted, privacy-focused search"
 license = {text = "AGPL-3.0-only"}
 requires-python = ">=3.10"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,7 @@ services:
     environment:
       - MEILI_URL=http://meilisearch:7700
       - MEILI_MASTER_KEY=${MEILI_MASTER_KEY}
-      - DATABASE_URL=sqlite:///data/onesearch.db
+      - DATABASE_URL=sqlite:////app/data/onesearch.db
       - LOG_LEVEL=${LOG_LEVEL:-INFO}
     ports:
       - "8000:8000"

--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -37,8 +37,8 @@ MEILI_MASTER_KEY=your-generated-key-here
 
 SQLite database path.
 
-- Default: `sqlite:///data/onesearch.db`
-- Example: `sqlite:///data/onesearch.db`
+- Default: `sqlite:////app/data/onesearch.db`
+- Example: `sqlite:////app/data/onesearch.db`
 
 The database stores source configurations and file metadata for incremental indexing.
 
@@ -176,7 +176,7 @@ Timeout for Office document extraction.
 MEILI_MASTER_KEY=YourSecureRandomKeyHere123456789
 
 # Optional - these show the defaults
-DATABASE_URL=sqlite:///data/onesearch.db
+DATABASE_URL=sqlite:////app/data/onesearch.db
 MEILI_URL=http://meilisearch:7700
 LOG_LEVEL=INFO
 
@@ -238,7 +238,7 @@ from pydantic_settings import BaseSettings
 
 class Settings(BaseSettings):
     meili_master_key: str
-    database_url: str = "sqlite:///data/onesearch.db"
+    database_url: str = "sqlite:////app/data/onesearch.db"
     log_level: str = "INFO"
     # ... etc
 ```

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "onesearch-frontend",
   "private": true,
-  "version": "0.7.0",
+  "version": "0.7.1",
   "license": "AGPL-3.0-only",
   "type": "module",
   "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onesearch"
-version = "0.7.0"
+version = "0.7.1"
 description = "Self-hosted, privacy-focused search for your homelab"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
App was completely broken on a real Proxmox CT deployment. Three bugs that all prevented the app from starting or functioning in Docker:

1. SQLite URLs used 3 slashes instead of 4 for absolute paths, so the database couldn't be created. Also the default path was /data/ instead of /app/data/ which is where the Dockerfile actually puts things. Fixed in config.py, docker-compose.yml, .env.example, alembic.ini, and docs.

2. alembic.ini had a hardcoded database URL that could conflict with DATABASE_URL. Removed it — env.py already handles this programmatically.

3. APScheduler's SQLAlchemy job store tried to pickle the scheduler's bound methods (which reference the SQLAlchemy engine), and that blows up. Switched to in-memory job store since _sync_all_jobs rebuilds everything from the database on startup anyway — the persistent store was redundant.

closes #68, closes #69, closes #70