### PR TITLE
Add code and config file types to search filters

### DIFF
--- a/backend/app/extractors/text.py
+++ b/backend/app/extractors/text.py
@@ -18,34 +18,44 @@ logger = logging.getLogger(__name__)
 
 class TextExtractor(BaseExtractor):
     """
-    Extractor for plain text files
+    Extractor for plain text files.
 
-    Supports:
-    - .txt - Plain text files
-    - .log - Log files
-    - .conf, .cfg, .ini - Configuration files
-    - .env.example - Environment example files
-    - .sh, .bash - Shell scripts
-    - .py, .js, .ts, .java, .c, .cpp, .h - Source code files
+    Extension → type mapping is the single source of truth.
+    SUPPORTED_EXTENSIONS is derived from it automatically.
     """
 
-    SUPPORTED_EXTENSIONS = [
-        '.txt', '.text',
-        '.log',
-        '.conf', '.cfg', '.config', '.ini',
-        '.env.example',
-        '.sh', '.bash', '.zsh',
-        '.py', '.pyw',
-        '.js', '.jsx', '.ts', '.tsx',
-        '.java', '.c', '.cpp', '.cc', '.h', '.hpp',
-        '.go', '.rs', '.rb', '.php',
-        '.css', '.scss', '.sass', '.less',
-        '.html', '.htm', '.xml', '.json', '.yaml', '.yml',
-        '.sql', '.r'
-    ]
+    # Single source of truth: extension → document type
+    EXTENSION_TYPES: dict[str, str] = {
+        # Plain text
+        '.txt': 'text', '.text': 'text', '.log': 'text',
+        # Code
+        '.py': 'code', '.pyw': 'code',
+        '.js': 'code', '.jsx': 'code', '.ts': 'code', '.tsx': 'code',
+        '.mjs': 'code', '.cjs': 'code',
+        '.java': 'code', '.c': 'code', '.cpp': 'code', '.cc': 'code',
+        '.h': 'code', '.hpp': 'code',
+        '.go': 'code', '.rs': 'code', '.rb': 'code', '.php': 'code',
+        '.cs': 'code', '.swift': 'code', '.kt': 'code',
+        '.css': 'code', '.scss': 'code', '.sass': 'code', '.less': 'code',
+        '.html': 'code', '.htm': 'code',
+        '.sh': 'code', '.bash': 'code', '.zsh': 'code', '.fish': 'code',
+        '.sql': 'code', '.r': 'code', '.lua': 'code',
+        # Config
+        '.conf': 'config', '.cfg': 'config', '.config': 'config',
+        '.ini': 'config', '.toml': 'config',
+        '.yaml': 'config', '.yml': 'config',
+        '.json': 'config', '.xml': 'config',
+        '.env': 'config',
+    }
+
+    SUPPORTED_EXTENSIONS = list(EXTENSION_TYPES.keys())
 
     # Max file size from settings
     MAX_FILE_SIZE = settings.max_text_file_size_mb * 1024 * 1024
+
+    def _type_for_extension(self, file_path: str) -> str:
+        ext = Path(file_path).suffix.lower()
+        return self.EXTENSION_TYPES.get(ext, 'text')
 
     # Timeout from settings
     TIMEOUT = settings.text_extraction_timeout
@@ -80,6 +90,7 @@ class TextExtractor(BaseExtractor):
 
             # Create base document
             doc = self._create_base_document(file_path, content)
+            doc.type = self._type_for_extension(file_path)
 
             # Try to extract title from first line (for code files, config files)
             doc.title = self._extract_title(file_path, content)
@@ -101,6 +112,7 @@ class TextExtractor(BaseExtractor):
             )
             # Create minimal document with just filename
             doc = self._create_base_document(file_path, "")
+            doc.type = self._type_for_extension(file_path)
             doc.title = Path(file_path).stem
             doc.metadata = {
                 "extraction_error": str(e),
@@ -117,6 +129,7 @@ class TextExtractor(BaseExtractor):
             )
             # Create minimal document
             doc = self._create_base_document(file_path, "")
+            doc.type = self._type_for_extension(file_path)
             doc.title = Path(file_path).stem
             doc.metadata = {
                 "extraction_error": str(e),

--- a/backend/tests/test_extractors.py
+++ b/backend/tests/test_extractors.py
@@ -106,6 +106,36 @@ class TestTextExtractor:
         assert not TextExtractor.supports_file(str(temp_dir / "test.pdf"))
 
     @pytest.mark.asyncio
+    async def test_code_file_type(self, temp_dir):
+        """Code files should get type 'code', not 'text'"""
+        for ext in ['.py', '.js', '.ts', '.go', '.sh']:
+            f = temp_dir / f"script{ext}"
+            f.write_text("print('hello')")
+            extractor = TextExtractor("src", "Source")
+            doc = await extractor.extract_with_timeout(str(f))
+            assert doc.type == "code", f"Expected 'code' for {ext}, got '{doc.type}'"
+
+    @pytest.mark.asyncio
+    async def test_config_file_type(self, temp_dir):
+        """Config files should get type 'config', not 'text'"""
+        for ext in ['.yaml', '.yml', '.toml', '.json', '.ini', '.env']:
+            f = temp_dir / f"config{ext}"
+            f.write_text("key: value")
+            extractor = TextExtractor("src", "Source")
+            doc = await extractor.extract_with_timeout(str(f))
+            assert doc.type == "config", f"Expected 'config' for {ext}, got '{doc.type}'"
+
+    @pytest.mark.asyncio
+    async def test_plain_text_still_text_type(self, temp_dir):
+        """Plain .txt and .log files should still be type 'text'"""
+        for ext in ['.txt', '.log', '.text']:
+            f = temp_dir / f"file{ext}"
+            f.write_text("some content")
+            extractor = TextExtractor("src", "Source")
+            doc = await extractor.extract_with_timeout(str(f))
+            assert doc.type == "text", f"Expected 'text' for {ext}, got '{doc.type}'"
+
+    @pytest.mark.asyncio
     async def test_file_size_limit(self, temp_dir):
         """Test file size limit enforcement"""
         # Create large file

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -212,6 +212,8 @@ export default function SearchPage() {
               <option value="">All Types</option>
               <option value="text">Text</option>
               <option value="markdown">Markdown</option>
+              <option value="code">Code</option>
+              <option value="config">Config</option>
               <option value="pdf">PDF</option>
               <option value="docx">Word (.docx)</option>
               <option value="xlsx">Excel (.xlsx)</option>


### PR DESCRIPTION
Closes #102.

`.py`, `.js`, `.go`, `.sh` etc now get indexed as `code` and `.yaml`, `.toml`, `.json`, `.env` etc as `config` instead of everything being lumped under `text`. Added both as filter options in the search UI.

The interesting part: the old approach had three separate lists (`SUPPORTED_EXTENSIONS`, `CODE_EXTENSIONS`, `CONFIG_EXTENSIONS`) that had to be kept in sync manually. Replaced all of that with a single `EXTENSION_TYPES` dict mapping extension → type, and `SUPPORTED_EXTENSIONS` is just derived from its keys. One place to edit if you ever want to add a new type.

Also dropped `.env.example` and `.dockerfile`/`.makefile` from the lists - they were dead code since `Path().suffix` can't match them (pre-existing issue).

Note: files already indexed will still show as `text` until re-indexed.