### PR TITLE
CLI works like a real client now

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -1,4 +1,4 @@
-name: Backend Tests
+name: Backend + CLI CI
 
 on:
   pull_request:
@@ -9,7 +9,9 @@ on:
       - main
     paths:
       - 'backend/**'
+      - 'cli/**'
       - 'pyproject.toml'
+      - 'uv.lock'
       - '.github/workflows/backend-tests.yml'
 
 jobs:
@@ -47,6 +49,20 @@ jobs:
       - name: Run backend tests
         run: |
           uv run pytest backend/tests/ -v --tb=short --color=yes --cov=app --cov-report=xml
+
+      - name: Run CLI tests
+        run: |
+          uv run pytest cli/tests/ -v --tb=short --color=yes
+
+      - name: Build onesearch-cli package
+        run: |
+          uv run --with build python -m build cli
+
+      - name: Upload onesearch-cli artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: onesearch-cli-dist
+          path: cli/dist/*
 
       - name: Upload coverage to Codecov
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,7 +1,7 @@
 # Copyright (C) 2025 demigodmode
 # SPDX-License-Identifier: AGPL-3.0-only
 
-name: Build and Push Docker Image
+name: Release Docker Image and CLI Package
 
 on:
   release:
@@ -24,6 +24,34 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: "latest"
+
+      - name: Build onesearch-cli package
+        run: |
+          uv run --with build python -m build cli
+
+      - name: Upload onesearch-cli artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: onesearch-cli-release-dist
+          path: cli/dist/*
+
+      - name: Publish onesearch-cli to PyPI
+        if: github.event_name == 'release' && secrets.PYPI_API_TOKEN != ''
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: |
+          uv run --with twine python -m twine upload cli/dist/*
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -35,6 +63,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Log in to Docker Hub
+        if: secrets.DOCKERHUB_USERNAME != '' && secrets.DOCKERHUB_TOKEN != ''
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY_DOCKER }}
@@ -48,17 +77,20 @@ jobs:
           images: |
             ${{ env.REGISTRY_GHCR }}/${{ env.IMAGE_NAME }}
             ${{ env.REGISTRY_DOCKER }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=${{ github.event_name == 'release' }}
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest
+            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
+            type=raw,value=manual,enable=${{ github.event_name == 'workflow_dispatch' }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
-          push: true
+          push: ${{ github.event_name == 'release' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=local,src=/tmp/.buildx-cache

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -70,13 +70,11 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Extract metadata (tags, labels)
-        id: meta
+      - name: Extract GHCR metadata (tags, labels)
+        id: meta-ghcr
         uses: docker/metadata-action@v5
         with:
-          images: |
-            ${{ env.REGISTRY_GHCR }}/${{ env.IMAGE_NAME }}
-            ${{ env.REGISTRY_DOCKER }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY_GHCR }}/${{ env.IMAGE_NAME }}
           flavor: |
             latest=${{ github.event_name == 'release' }}
           tags: |
@@ -85,14 +83,41 @@ jobs:
             type=raw,value=latest,enable=${{ github.event_name == 'release' }}
             type=raw,value=manual,enable=${{ github.event_name == 'workflow_dispatch' }}
 
+      - name: Extract Docker Hub metadata (tags, labels)
+        if: secrets.DOCKERHUB_USERNAME != '' && secrets.DOCKERHUB_TOKEN != ''
+        id: meta-dockerhub
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_DOCKER }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=${{ github.event_name == 'release' }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
+            type=raw,value=manual,enable=${{ github.event_name == 'workflow_dispatch' }}
+
+      - name: Collect image tags
+        id: image-tags
+        shell: bash
+        run: |
+          {
+            echo 'tags<<EOF'
+            printf '%s\n' "${{ steps.meta-ghcr.outputs.tags }}"
+            if [ -n "${{ steps.meta-dockerhub.outputs.tags }}" ]; then
+              printf '%s\n' "${{ steps.meta-dockerhub.outputs.tags }}"
+            fi
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
           push: ${{ github.event_name == 'release' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.image-tags.outputs.tags }}
+          labels: ${{ steps.meta-ghcr.outputs.labels }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
           platforms: linux/amd64,linux/arm64

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Accent color theming - pick what feels like yours:
 
 - [Installation Guide](https://onesearch.readthedocs.io/en/latest/getting-started/installation/)
 - [User Guide](https://onesearch.readthedocs.io/en/latest/user-guide/)
-- [CLI Reference](https://onesearch.readthedocs.io/en/latest/cli/)
+- [CLI Reference](https://onesearch.readthedocs.io/en/latest/cli/) - standalone `onesearch-cli` package that connects to your running OneSearch server and ships from the same tagged release as the Docker image
 - [API Reference](https://onesearch.readthedocs.io/en/latest/api/)
 
 ---

--- a/cli/README.md
+++ b/cli/README.md
@@ -4,6 +4,16 @@ Command-line interface for OneSearch - Self-hosted, privacy-focused search for y
 
 ## Installation
 
+The CLI is a standalone client for a running OneSearch server. It does not include the backend, indexer, or search data. Tagged OneSearch releases publish the Docker image and the `onesearch-cli` package together on the same shared version.
+
+### Recommended: pipx
+
+```bash
+pipx install onesearch-cli
+onesearch config set backend_url http://localhost:8000
+onesearch login
+```
+
 ### From Source (Development)
 
 ```bash
@@ -108,13 +118,18 @@ onesearch health --json
 ### Environment Variables
 
 - `ONESEARCH_URL` - Backend API URL (default: `http://localhost:8000`)
+- `ONESEARCH_TOKEN` - Bearer token for non-interactive auth
 
 ```bash
 # Use a custom backend URL
 export ONESEARCH_URL=http://onesearch.local:8000
 onesearch search "test"
 
-# Or pass directly
+# Non-interactive auth for scripts
+export ONESEARCH_TOKEN=xxxxx
+onesearch search "test" --json
+
+# Or pass the URL directly
 onesearch --url http://onesearch.local:8000 search "test"
 ```
 

--- a/cli/onesearch/api.py
+++ b/cli/onesearch/api.py
@@ -46,6 +46,7 @@ class OneSearchAPI:
         endpoint: str,
         params: dict | None = None,
         json: dict | None = None,
+        allow_status_codes: set[int] | None = None,
     ) -> Any:
         """Make an API request.
 
@@ -70,6 +71,11 @@ class OneSearchAPI:
                 json=json,
                 timeout=self.timeout,
             )
+            if allow_status_codes and response.status_code in allow_status_codes:
+                if response.content:
+                    return response.json()
+                return None
+
             response.raise_for_status()
             if response.content:
                 return response.json()
@@ -116,9 +122,10 @@ class OneSearchAPI:
         return self._request("GET", "/api/auth/status")
 
     # Health endpoints
-    def health(self) -> dict:
+    def health(self, allow_degraded: bool = False) -> dict:
         """Check system health."""
-        return self._request("GET", "/api/health")
+        allowed = {503} if allow_degraded else None
+        return self._request("GET", "/api/health", allow_status_codes=allowed)
 
     def status(self) -> dict:
         """Get system status."""

--- a/cli/onesearch/api.py
+++ b/cli/onesearch/api.py
@@ -22,16 +22,19 @@ class APIError(Exception):
 class OneSearchAPI:
     """Client for the OneSearch backend API."""
 
-    def __init__(self, base_url: str = "http://localhost:8000", timeout: int = 30):
+    def __init__(self, base_url: str = "http://localhost:8000", timeout: int = 30, token: str | None = None):
         """Initialize the API client.
 
         Args:
             base_url: Backend API base URL.
             timeout: Request timeout in seconds.
+            token: Optional bearer token.
         """
         self.base_url = base_url.rstrip("/")
         self.timeout = timeout
         self.session = requests.Session()
+        if token:
+            self.session.headers.update({"Authorization": f"Bearer {token}"})
 
     def _url(self, endpoint: str) -> str:
         """Build full URL for an endpoint."""
@@ -71,13 +74,13 @@ class OneSearchAPI:
             if response.content:
                 return response.json()
             return None
-        except requests.exceptions.ConnectionError:
+        except requests.exceptions.ConnectionError as err:
             raise APIError(
                 f"Could not connect to OneSearch at {self.base_url}. "
                 "Is the server running?"
-            )
-        except requests.exceptions.Timeout:
-            raise APIError(f"Request to {url} timed out after {self.timeout}s")
+            ) from err
+        except requests.exceptions.Timeout as err:
+            raise APIError(f"Request to {url} timed out after {self.timeout}s") from err
         except requests.exceptions.HTTPError as e:
             status_code = e.response.status_code
             try:
@@ -86,7 +89,31 @@ class OneSearchAPI:
             except Exception:
                 details = None
                 message = str(e)
-            raise APIError(message, status_code=status_code, details=details)
+
+            if status_code in (401, 403):
+                message = f"{message}. Run 'onesearch login' or set ONESEARCH_TOKEN."
+
+            raise APIError(message, status_code=status_code, details=details) from e
+
+    def login(self, username: str, password: str) -> dict:
+        """Authenticate and return token payload."""
+        return self._request(
+            "POST",
+            "/api/auth/login",
+            json={"username": username, "password": password},
+        )
+
+    def logout(self) -> dict:
+        """Logout current user."""
+        return self._request("POST", "/api/auth/logout")
+
+    def whoami(self) -> dict:
+        """Return current user info."""
+        return self._request("GET", "/api/auth/me")
+
+    def auth_status(self) -> dict:
+        """Return auth setup status."""
+        return self._request("GET", "/api/auth/status")
 
     # Health endpoints
     def health(self) -> dict:

--- a/cli/onesearch/banner.py
+++ b/cli/onesearch/banner.py
@@ -1,0 +1,84 @@
+# Copyright (C) 2025 demigodmode
+# SPDX-License-Identifier: AGPL-3.0-only
+
+"""Startup banner rendering for the OneSearch CLI."""
+
+from __future__ import annotations
+
+from rich.console import Group
+from rich.panel import Panel
+from rich.text import Text
+
+
+def _version_tuple(version: str | None) -> tuple[int, ...]:
+    if not version:
+        return ()
+    parts = []
+    for chunk in version.split("."):
+        digits = "".join(ch for ch in chunk if ch.isdigit())
+        if not digits:
+            break
+        parts.append(int(digits))
+    return tuple(parts)
+
+
+def build_startup_panel(
+    *,
+    configured: bool,
+    backend_url: str | None,
+    server_status: str | None = None,
+    auth_state: str | None = None,
+    cli_version: str | None = None,
+    server_version: str | None = None,
+    error_message: str | None = None,
+):
+    """Build the startup banner panel."""
+    lines: list[str] = []
+    title = Text("OneSearch", style="bold cyan")
+
+    if cli_version:
+        lines.append(f"CLI: {cli_version}")
+    if server_version:
+        lines.append(f"Server: {server_version}")
+    if backend_url:
+        lines.append(f"Backend: {backend_url}")
+
+    if not configured:
+        lines.extend(
+            [
+                "",
+                "No backend configured.",
+                "Run: onesearch config set backend_url http://host:8000",
+                "Then: onesearch login",
+            ]
+        )
+        return Panel("\n".join(lines), title=title)
+
+    if auth_state:
+        lines.append(f"Auth: {auth_state}")
+    if server_status:
+        lines.append(f"Status: {server_status}")
+
+    if error_message:
+        lines.extend(["", f"Error: {error_message}"])
+
+    if _version_tuple(server_version) > _version_tuple(cli_version):
+        lines.extend(
+            [
+                "",
+                "Update available: server is newer than this CLI. Consider updating onesearch-cli.",
+            ]
+        )
+
+    if not error_message:
+        lines.extend(
+            [
+                "",
+                "Try:",
+                '  onesearch search "compose"',
+                "  onesearch source list",
+                "  onesearch status",
+            ]
+        )
+
+    return Panel(Group(*lines), title=title)

--- a/cli/onesearch/commands/auth.py
+++ b/cli/onesearch/commands/auth.py
@@ -1,0 +1,64 @@
+# Copyright (C) 2025 demigodmode
+# SPDX-License-Identifier: AGPL-3.0-only
+
+"""Authentication commands."""
+
+import click
+
+from onesearch.api import APIError
+from onesearch.config import delete_config_value, set_config_value
+from onesearch.context import Context, console, err_console, pass_context
+from onesearch.main import cli
+
+
+@cli.command()
+@click.option("--token", "use_token", is_flag=True, help="Prompt for a bearer token instead of username/password.")
+@pass_context
+def login(ctx: Context, use_token: bool):
+    """Authenticate and store a CLI token."""
+    if use_token:
+        token = click.prompt("Token", hide_input=False)
+        set_config_value("auth.token", token)
+        ctx.reset_api()
+        console.print("[green]✓[/green] Token stored for OneSearch CLI")
+        return
+
+    username = click.prompt("Username")
+    password = click.prompt("Password", hide_input=True)
+
+    api = ctx.get_api()
+    try:
+        result = api.login(username, password)
+        token = result.get("access_token")
+        if not token:
+            raise click.ClickException("Login succeeded but no access token was returned.")
+
+        set_config_value("auth.token", token)
+        ctx.reset_api()
+        console.print(f"[green]✓[/green] Logged in as [cyan]{username}[/cyan]")
+    except APIError as e:
+        err_console.print(f"[red]Error:[/red] {e.message}")
+        raise SystemExit(1) from e
+
+
+@cli.command()
+@pass_context
+def logout(ctx: Context):
+    """Remove the stored CLI token."""
+    delete_config_value("auth.token")
+    ctx.reset_api()
+    console.print("[green]✓[/green] Logged out")
+
+
+@cli.command()
+@pass_context
+def whoami(ctx: Context):
+    """Show the current authenticated user."""
+    api = ctx.get_api()
+    try:
+        user = api.whoami()
+        console.print(f"Logged in as [cyan]{user.get('username', 'unknown')}[/cyan]")
+        console.print(f"Backend: [dim]{ctx.url}[/dim]")
+    except APIError as e:
+        err_console.print(f"[red]Error:[/red] {e.message}")
+        raise SystemExit(1) from e

--- a/cli/onesearch/commands/config.py
+++ b/cli/onesearch/commands/config.py
@@ -7,12 +7,12 @@ import click
 import yaml
 
 from onesearch.config import (
-    get_config_path,
-    load_config,
-    get_config_value,
-    set_config_value,
-    delete_config_value,
     DEFAULT_CONFIG,
+    delete_config_value,
+    get_config_path,
+    get_config_value,
+    load_config,
+    set_config_value,
 )
 from onesearch.context import console, err_console
 from onesearch.main import cli
@@ -34,6 +34,7 @@ def config():
       onesearch config show
       onesearch config set backend_url http://onesearch.local:8000
       onesearch config get backend_url
+      onesearch config path
     """
     pass
 
@@ -157,3 +158,9 @@ def config_init(force: bool):
 
     console.print(f"[green]✓[/green] Created config file: {config_path}")
     console.print("\nEdit this file or use [cyan]onesearch config set <key> <value>[/cyan]")
+
+
+@config.command("path")
+def config_path_command():
+    """Show the configuration file path."""
+    console.print(str(get_config_path()))

--- a/cli/onesearch/commands/search.py
+++ b/cli/onesearch/commands/search.py
@@ -10,7 +10,7 @@ from rich.markup import escape
 from rich.text import Text
 
 from onesearch.api import APIError
-from onesearch.context import Context, pass_context, console, err_console
+from onesearch.context import Context, console, err_console, pass_context
 from onesearch.main import cli
 
 
@@ -139,4 +139,4 @@ def search(
 
     except APIError as e:
         err_console.print(f"[red]Error:[/red] {e.message}")
-        raise SystemExit(1)
+        raise SystemExit(1) from e

--- a/cli/onesearch/commands/source.py
+++ b/cli/onesearch/commands/source.py
@@ -7,7 +7,7 @@ import click
 from rich.table import Table
 
 from onesearch.api import APIError
-from onesearch.context import Context, pass_context, console, err_console
+from onesearch.context import Context, console, err_console, pass_context
 from onesearch.main import cli
 
 
@@ -72,7 +72,7 @@ def source_list(ctx: Context):
         console.print(table)
     except APIError as e:
         err_console.print(f"[red]Error:[/red] {e.message}")
-        raise SystemExit(1)
+        raise SystemExit(1) from e
 
 
 @source.command("add")
@@ -131,7 +131,7 @@ def source_add(ctx: Context, name: str, path: str, include: str | None, exclude:
         out.print("\nRun [cyan]onesearch source reindex {id}[/cyan] to start indexing.".format(id=result['id']))
     except APIError as e:
         err_console.print(f"[red]Error:[/red] {e.message}")
-        raise SystemExit(1)
+        raise SystemExit(1) from e
 
 
 @source.command("show")
@@ -157,7 +157,7 @@ def source_show(ctx: Context, source_id: str):
             console.print(f"  Updated:          {s['updated_at']}")
     except APIError as e:
         err_console.print(f"[red]Error:[/red] {e.message}")
-        raise SystemExit(1)
+        raise SystemExit(1) from e
 
 
 @source.command("delete")
@@ -191,7 +191,7 @@ def source_delete(ctx: Context, source_id: str, yes: bool):
         ctx.get_console().print(f"[green]✓[/green] Deleted source [cyan]{s['name']}[/cyan]")
     except APIError as e:
         err_console.print(f"[red]Error:[/red] {e.message}")
-        raise SystemExit(1)
+        raise SystemExit(1) from e
 
 
 @source.command("reindex")
@@ -229,4 +229,4 @@ def source_reindex(ctx: Context, source_id: str):
             out.print(f"  Skipped:      {stats.get('skipped', 0)}")
     except APIError as e:
         err_console.print(f"[red]Error:[/red] {e.message}")
-        raise SystemExit(1)
+        raise SystemExit(1) from e

--- a/cli/onesearch/commands/status.py
+++ b/cli/onesearch/commands/status.py
@@ -10,8 +10,8 @@ import click
 from rich.table import Table
 
 from onesearch.api import APIError
-from onesearch.config import get_config_path, get_backend_url
-from onesearch.context import Context, pass_context, console, err_console
+from onesearch.config import get_config_path
+from onesearch.context import Context, console, err_console, pass_context
 from onesearch.main import cli
 
 
@@ -68,7 +68,7 @@ def status(ctx: Context, source_id: str | None, as_json: bool):
             if failed > 0:
                 console.print(f"  [red]Failed:     {failed} ✗[/red]")
             else:
-                console.print(f"  Failed:     0")
+                console.print("  Failed:     0")
 
             skipped = result.get("skipped", 0)
             if skipped > 0:
@@ -116,7 +116,7 @@ def status(ctx: Context, source_id: str | None, as_json: bool):
                         f"{s.get('source_name', 'Unknown')} ({s.get('source_id', '?')})",
                         "-",
                         "-",
-                        f"[red]Error[/red]",
+                        "[red]Error[/red]",
                         "-",
                         "-",
                     )
@@ -142,7 +142,7 @@ def status(ctx: Context, source_id: str | None, as_json: bool):
 
     except APIError as e:
         err_console.print(f"[red]Error:[/red] {e.message}")
-        raise SystemExit(1)
+        raise SystemExit(1) from e
 
 
 @cli.command()
@@ -193,7 +193,7 @@ def health(ctx: Context, as_json: bool):
         meili = result.get("meilisearch", {})
         meili_status = meili.get("status", "unknown")
         if meili_status in ("available", "healthy"):
-            out.print(f"  Meilisearch: Connected [green]✓[/green]")
+            out.print("  Meilisearch: Connected [green]✓[/green]")
         else:
             out.print(f"  Meilisearch: [yellow]{meili_status}[/yellow]")
 
@@ -201,21 +201,21 @@ def health(ctx: Context, as_json: bool):
         out.print("[bold]Configuration:[/bold]")
         out.print(f"  Config file: {config_path}")
         if config_path.exists():
-            out.print(f"  Config:      [green]Loaded[/green]")
+            out.print("  Config:      [green]Loaded[/green]")
         else:
-            out.print(f"  Config:      [dim]Using defaults[/dim]")
+            out.print("  Config:      [dim]Using defaults[/dim]")
         out.print()
 
     except APIError as e:
-        err_console.print(f"[red]✗ System Unhealthy[/red]")
+        err_console.print("[red]✗ System Unhealthy[/red]")
         err_console.print(f"\n  Backend: {ctx.url} [red]✗[/red]")
         err_console.print(f"  Error: {e.message}")
         err_console.print()
         err_console.print("[bold]Configuration:[/bold]")
         err_console.print(f"  Config file: {config_path}")
         if config_path.exists():
-            err_console.print(f"  Config:      [green]Loaded[/green]")
+            err_console.print("  Config:      [green]Loaded[/green]")
         else:
-            err_console.print(f"  Config:      [dim]Using defaults[/dim]")
+            err_console.print("  Config:      [dim]Using defaults[/dim]")
         console.print()
-        raise SystemExit(1)
+        raise SystemExit(1) from e

--- a/cli/onesearch/config.py
+++ b/cli/onesearch/config.py
@@ -36,7 +36,7 @@ def load_config() -> dict:
         return {}
 
     try:
-        with open(config_path, "r") as f:
+        with open(config_path) as f:
             config = yaml.safe_load(f) or {}
             return config
     except Exception:
@@ -137,18 +137,29 @@ def get_backend_url() -> str:
     2. Config file backend_url
     3. Default http://localhost:8000
     """
-    # Check environment first
     env_url = os.environ.get("ONESEARCH_URL")
     if env_url:
         return env_url
 
-    # Check config file
     config_url = get_config_value("backend_url")
     if config_url:
         return config_url
 
-    # Default
     return "http://localhost:8000"
+
+
+def get_auth_token() -> str | None:
+    """Get auth token from env/config.
+
+    Priority:
+    1. Environment variable ONESEARCH_TOKEN
+    2. Config file auth.token
+    """
+    env_token = os.environ.get("ONESEARCH_TOKEN")
+    if env_token:
+        return env_token
+
+    return get_config_value("auth.token")
 
 
 # Default configuration template
@@ -158,6 +169,10 @@ DEFAULT_CONFIG = """\
 
 # Backend API URL
 backend_url: http://localhost:8000
+
+# Authentication
+auth:
+  token: null
 
 # Output settings
 output:

--- a/cli/onesearch/context.py
+++ b/cli/onesearch/context.py
@@ -9,6 +9,7 @@ import click
 from rich.console import Console
 
 from onesearch.api import OneSearchAPI
+from onesearch.config import get_auth_token
 
 # Rich console for output
 console = Console()
@@ -26,12 +27,19 @@ class Context:
         self.verbose: bool = False
         self.quiet: bool = False
         self.url: str = "http://localhost:8000"
+        self.token: str | None = None
 
     def get_api(self) -> OneSearchAPI:
         """Get or create the API client."""
         if self.api is None:
-            self.api = OneSearchAPI(base_url=self.url)
+            self.token = get_auth_token()
+            self.api = OneSearchAPI(base_url=self.url, token=self.token)
         return self.api
+
+    def reset_api(self) -> None:
+        """Clear cached API client after config/auth changes."""
+        self.api = None
+        self.token = None
 
     def get_console(self) -> Console:
         """Get the appropriate console based on quiet mode."""

--- a/cli/onesearch/main.py
+++ b/cli/onesearch/main.py
@@ -3,12 +3,16 @@
 
 """OneSearch CLI entry point."""
 
+import os
 import sys
 
 import click
 
 from onesearch import __version__
-from onesearch.context import Context, pass_context, console, err_console
+from onesearch.api import APIError
+from onesearch.banner import build_startup_panel
+from onesearch.config import load_config
+from onesearch.context import Context, console, err_console
 
 # Context settings for all commands
 CONTEXT_SETTINGS = {
@@ -22,7 +26,69 @@ def get_default_url() -> str:
     return get_backend_url()
 
 
-@click.group(context_settings=CONTEXT_SETTINGS)
+def _has_configured_backend() -> bool:
+    config_data = load_config()
+    return bool(os.environ.get("ONESEARCH_URL") or config_data.get("backend_url"))
+
+
+def _render_startup_panel(ctx: Context) -> None:
+    configured = _has_configured_backend()
+    if not configured:
+        console.print(
+            build_startup_panel(
+                configured=False,
+                backend_url=None,
+                cli_version=__version__,
+            )
+        )
+        return
+
+    api = ctx.get_api()
+    try:
+        health = api.health()
+        server_version = health.get("version")
+        server_status = health.get("status", "unknown")
+        auth_state = "not logged in"
+
+        try:
+            user = api.whoami()
+            auth_state = f"logged in as {user.get('username', 'unknown')}"
+        except APIError as auth_error:
+            if auth_error.status_code not in (401, 403):
+                console.print(
+                    build_startup_panel(
+                        configured=True,
+                        backend_url=ctx.url,
+                        cli_version=__version__,
+                        server_version=server_version,
+                        server_status=server_status,
+                        error_message=auth_error.message,
+                    )
+                )
+                return
+
+        console.print(
+            build_startup_panel(
+                configured=True,
+                backend_url=ctx.url,
+                cli_version=__version__,
+                server_version=server_version,
+                server_status=server_status,
+                auth_state=auth_state,
+            )
+        )
+    except APIError as e:
+        console.print(
+            build_startup_panel(
+                configured=True,
+                backend_url=ctx.url,
+                cli_version=__version__,
+                error_message=e.message,
+            )
+        )
+
+
+@click.group(context_settings=CONTEXT_SETTINGS, invoke_without_command=True)
 @click.version_option(version=__version__, prog_name="onesearch")
 @click.option(
     "--url",
@@ -41,8 +107,8 @@ def get_default_url() -> str:
     is_flag=True,
     help="Suppress non-essential output. Only show results/errors.",
 )
-@pass_context
-def cli(ctx: Context, url: str, verbose: bool, quiet: bool):
+@click.pass_context
+def cli(click_ctx: click.Context, url: str, verbose: bool, quiet: bool):
     """OneSearch - Self-hosted, privacy-focused search for your homelab.
 
     Search across all your files, documents, and notes from a single,
@@ -57,13 +123,17 @@ def cli(ctx: Context, url: str, verbose: bool, quiet: bool):
 
     Use 'onesearch COMMAND --help' for more information on a command.
     """
+    ctx = click_ctx.ensure_object(Context)
     ctx.url = url
     ctx.verbose = verbose
     ctx.quiet = quiet
 
+    if click_ctx.invoked_subcommand is None:
+        _render_startup_panel(ctx)
+
 
 # Import and register command groups after cli is defined
-from onesearch.commands import source, search, status, config  # noqa: E402, F401
+from onesearch.commands import auth, config, search, source, status  # noqa: E402, F401
 
 
 def main():

--- a/cli/onesearch/main.py
+++ b/cli/onesearch/main.py
@@ -26,13 +26,13 @@ def get_default_url() -> str:
     return get_backend_url()
 
 
-def _has_configured_backend() -> bool:
+def _has_configured_backend(resolved_url: str | None = None) -> bool:
     config_data = load_config()
-    return bool(os.environ.get("ONESEARCH_URL") or config_data.get("backend_url"))
+    return bool(resolved_url or os.environ.get("ONESEARCH_URL") or config_data.get("backend_url"))
 
 
 def _render_startup_panel(ctx: Context) -> None:
-    configured = _has_configured_backend()
+    configured = _has_configured_backend(ctx.url)
     if not configured:
         console.print(
             build_startup_panel(
@@ -45,7 +45,7 @@ def _render_startup_panel(ctx: Context) -> None:
 
     api = ctx.get_api()
     try:
-        health = api.health()
+        health = api.health(allow_degraded=True)
         server_version = health.get("version")
         server_status = health.get("status", "unknown")
         auth_state = "not logged in"

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -1,7 +1,8 @@
 [project]
 name = "onesearch-cli"
 version = "0.11.1"
-description = "CLI for OneSearch - Self-hosted, privacy-focused search"
+description = "Standalone CLI client for a running OneSearch server"
+readme = "README.md"
 license = {text = "AGPL-3.0-only"}
 requires-python = ">=3.10"
 dependencies = [

--- a/cli/tests/test_api.py
+++ b/cli/tests/test_api.py
@@ -5,16 +5,17 @@ from onesearch.api import APIError, OneSearchAPI
 
 
 class DummyResponse:
-    def __init__(self, status_code=401, detail="Not authenticated"):
+    def __init__(self, status_code=401, detail="Not authenticated", payload=None):
         self.status_code = status_code
         self._detail = detail
+        self._payload = payload or {"detail": detail}
         self.content = b'{"detail":"%s"}' % detail.encode()
 
     def raise_for_status(self):
         raise requests.exceptions.HTTPError(response=self)
 
     def json(self):
-        return {"detail": self._detail}
+        return self._payload
 
 
 def test_api_client_sets_bearer_token():
@@ -34,3 +35,21 @@ def test_auth_error_message_is_actionable(monkeypatch):
         api._request("GET", "/api/status")
 
     assert "onesearch login" in exc.value.message
+
+
+def test_health_allows_degraded_responses(monkeypatch):
+    api = OneSearchAPI(base_url="http://localhost:8000")
+
+    def fake_request(**kwargs):
+        return DummyResponse(
+            status_code=503,
+            detail="degraded",
+            payload={"status": "degraded", "version": "0.11.1"},
+        )
+
+    monkeypatch.setattr(api.session, "request", fake_request)
+
+    result = api.health(allow_degraded=True)
+
+    assert result["status"] == "degraded"
+    assert result["version"] == "0.11.1"

--- a/cli/tests/test_api.py
+++ b/cli/tests/test_api.py
@@ -1,0 +1,36 @@
+import pytest
+import requests
+
+from onesearch.api import APIError, OneSearchAPI
+
+
+class DummyResponse:
+    def __init__(self, status_code=401, detail="Not authenticated"):
+        self.status_code = status_code
+        self._detail = detail
+        self.content = b'{"detail":"%s"}' % detail.encode()
+
+    def raise_for_status(self):
+        raise requests.exceptions.HTTPError(response=self)
+
+    def json(self):
+        return {"detail": self._detail}
+
+
+def test_api_client_sets_bearer_token():
+    api = OneSearchAPI(base_url="http://localhost:8000", token="secret")
+    assert api.session.headers["Authorization"] == "Bearer secret"
+
+
+def test_auth_error_message_is_actionable(monkeypatch):
+    api = OneSearchAPI(base_url="http://localhost:8000")
+
+    def fake_request(**kwargs):
+        return DummyResponse()
+
+    monkeypatch.setattr(api.session, "request", fake_request)
+
+    with pytest.raises(APIError) as exc:
+        api._request("GET", "/api/status")
+
+    assert "onesearch login" in exc.value.message

--- a/cli/tests/test_auth_commands.py
+++ b/cli/tests/test_auth_commands.py
@@ -1,0 +1,33 @@
+from click.testing import CliRunner
+
+from onesearch.main import cli
+
+
+def test_login_command_exists():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["login", "--help"])
+    assert result.exit_code == 0
+    assert "login" in result.output.lower()
+
+
+def test_login_with_token_stores_token(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setenv("APPDATA", str(tmp_path))
+    runner = CliRunner()
+    result = runner.invoke(cli, ["login", "--token"], input="abc123\n")
+    assert result.exit_code == 0
+    assert "stored" in result.output.lower()
+
+
+def test_logout_command_exists():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["logout", "--help"])
+    assert result.exit_code == 0
+    assert "logout" in result.output.lower()
+
+
+def test_whoami_command_exists():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["whoami", "--help"])
+    assert result.exit_code == 0
+    assert "whoami" in result.output.lower()

--- a/cli/tests/test_banner.py
+++ b/cli/tests/test_banner.py
@@ -1,0 +1,43 @@
+import io
+
+from rich.console import Console
+
+from onesearch.banner import build_startup_panel
+
+
+def render_text(renderable):
+    buffer = io.StringIO()
+    console = Console(file=buffer, force_terminal=False, width=120)
+    console.print(renderable)
+    return buffer.getvalue()
+
+
+def test_unconfigured_banner_mentions_backend_setup():
+    panel = build_startup_panel(configured=False, backend_url=None)
+    output = render_text(panel)
+    assert "backend" in output.lower()
+    assert "config set backend_url" in output.lower()
+
+
+def test_healthy_banner_shows_versions():
+    panel = build_startup_panel(
+        configured=True,
+        backend_url="http://infra-stack:8000",
+        server_status="healthy",
+        auth_state="logged in as admin",
+        cli_version="0.11.1",
+        server_version="0.12.0",
+    )
+    output = render_text(panel)
+    assert "cli: 0.11.1" in output.lower()
+    assert "server: 0.12.0" in output.lower()
+
+
+def test_error_banner_shows_unreachable_message():
+    panel = build_startup_panel(
+        configured=True,
+        backend_url="http://infra-stack:8000",
+        error_message="backend unreachable",
+    )
+    output = render_text(panel)
+    assert "backend unreachable" in output.lower()

--- a/cli/tests/test_config.py
+++ b/cli/tests/test_config.py
@@ -1,0 +1,17 @@
+from onesearch.config import get_auth_token, get_backend_url, get_config_value, set_config_value
+
+
+def test_backend_url_defaults_to_localhost(monkeypatch, tmp_path):
+    monkeypatch.delenv("ONESEARCH_URL", raising=False)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setenv("APPDATA", str(tmp_path))
+    assert get_backend_url() == "http://localhost:8000"
+
+
+def test_auth_token_round_trip(tmp_path, monkeypatch):
+    monkeypatch.delenv("ONESEARCH_TOKEN", raising=False)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setenv("APPDATA", str(tmp_path))
+    set_config_value("auth.token", "abc123")
+    assert get_config_value("auth.token") == "abc123"
+    assert get_auth_token() == "abc123"

--- a/cli/tests/test_integration_auth.py
+++ b/cli/tests/test_integration_auth.py
@@ -1,0 +1,120 @@
+from urllib.parse import urlparse
+
+import pytest
+import requests
+from click.testing import CliRunner
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.api.auth import hash_password
+from app.db.database import get_db
+from app.main import app
+from app.models import Base, User
+from onesearch.config import get_auth_token
+from onesearch.context import Context
+from onesearch.main import cli
+
+SQLALCHEMY_DATABASE_URL = "sqlite:///:memory:"
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL,
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+class ResponseAdapter:
+    def __init__(self, response):
+        self.status_code = response.status_code
+        self.content = response.content
+        self._response = response
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.exceptions.HTTPError(response=self)
+
+    def json(self):
+        return self._response.json()
+
+
+@pytest.fixture
+def db_session():
+    Base.metadata.create_all(bind=engine)
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+        Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture
+def backend_client(db_session):
+    def override_get_db():
+        try:
+            yield db_session
+        finally:
+            pass
+
+    app.dependency_overrides[get_db] = override_get_db
+    with TestClient(app) as test_client:
+        yield test_client
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def sample_user(db_session):
+    user = User(
+        username="testuser",
+        password_hash=hash_password("testpass"),
+        is_active=True,
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    return user
+
+
+@pytest.fixture
+def cli_backend(monkeypatch, backend_client):
+    def fake_request(session_self, method, url, params=None, json=None, timeout=None, **kwargs):
+        parsed = urlparse(url)
+        headers = dict(session_self.headers)
+        headers.update(kwargs.get("headers") or {})
+        response = backend_client.request(method, parsed.path, params=params, json=json, headers=headers)
+        return ResponseAdapter(response)
+
+    monkeypatch.setattr(requests.Session, "request", fake_request)
+
+
+def test_login_stores_token_and_whoami_uses_it(cli_backend, sample_user, monkeypatch, tmp_path):
+    monkeypatch.delenv("ONESEARCH_TOKEN", raising=False)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setenv("APPDATA", str(tmp_path))
+    runner = CliRunner()
+
+    login_result = runner.invoke(
+        cli,
+        ["--url", "http://testserver", "login"],
+        input="testuser\ntestpass\n",
+        obj=Context(),
+    )
+    assert login_result.exit_code == 0
+    assert get_auth_token()
+
+    whoami_result = runner.invoke(cli, ["--url", "http://testserver", "whoami"], obj=Context())
+    assert whoami_result.exit_code == 0
+    assert "testuser" in whoami_result.output
+
+
+def test_whoami_without_token_shows_actionable_error(cli_backend, sample_user, monkeypatch, tmp_path):
+    monkeypatch.delenv("ONESEARCH_TOKEN", raising=False)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setenv("APPDATA", str(tmp_path))
+    runner = CliRunner()
+
+    result = runner.invoke(cli, ["--url", "http://testserver", "whoami"], obj=Context())
+    assert result.exit_code == 1
+    assert "onesearch login" in result.output

--- a/cli/tests/test_main.py
+++ b/cli/tests/test_main.py
@@ -1,0 +1,14 @@
+from click.testing import CliRunner
+
+from onesearch.main import cli
+
+
+def test_cli_group_exists():
+    assert cli.name == "cli" or cli is not None
+
+
+def test_no_args_shows_startup_panel():
+    runner = CliRunner()
+    result = runner.invoke(cli, [])
+    assert result.exit_code == 0
+    assert "OneSearch" in result.output

--- a/cli/tests/test_main.py
+++ b/cli/tests/test_main.py
@@ -1,5 +1,7 @@
 from click.testing import CliRunner
 
+from onesearch.api import APIError
+from onesearch.context import Context
 from onesearch.main import cli
 
 
@@ -12,3 +14,30 @@ def test_no_args_shows_startup_panel():
     result = runner.invoke(cli, [])
     assert result.exit_code == 0
     assert "OneSearch" in result.output
+
+
+def test_no_args_with_explicit_url_does_not_show_unconfigured(monkeypatch):
+    monkeypatch.setattr("onesearch.main._render_startup_panel", lambda ctx: print(f"startup:{ctx.url}"))
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--url", "http://testserver"], obj=Context())
+    assert result.exit_code == 0
+    assert "startup:http://testserver" in result.output
+
+
+def test_no_args_with_degraded_backend_shows_degraded_status(monkeypatch):
+    class FakeAPI:
+        def health(self, allow_degraded=False):
+            assert allow_degraded is True
+            return {"status": "degraded", "version": "0.12.0"}
+
+        def whoami(self):
+            raise APIError("Not authenticated", status_code=401)
+
+    monkeypatch.setattr("onesearch.main._has_configured_backend", lambda resolved_url=None: True)
+    monkeypatch.setattr(Context, "get_api", lambda self: FakeAPI())
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--url", "http://testserver"], obj=Context())
+    assert result.exit_code == 0
+    assert "Status: degraded" in result.output
+    assert "Error:" not in result.output

--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -1,20 +1,48 @@
 # CLI Configuration
 
-Configure the OneSearch CLI.
-
-!!! note "Coming Soon"
-    Detailed configuration guide coming soon.
+Configure the standalone OneSearch CLI client.
 
 ## Config File
 
 Located at:
-- Linux/macOS: `~/.config/onesearch/config.json`
-- Windows: `%APPDATA%\onesearch\config.json`
+- Linux/macOS: `~/.config/onesearch/config.yml`
+- Windows: `%APPDATA%\onesearch\config.yml`
 
-## Environment Variables
+Example:
+
+```yaml
+backend_url: http://infra-stack:8000
+auth:
+  token: null
+output:
+  colors: true
+  format: table
+```
+
+## Interactive login
 
 ```bash
-export ONESEARCH_URL=http://localhost:8000
+onesearch config set backend_url http://infra-stack:8000
+onesearch login
+onesearch whoami
+```
+
+## Environment variables
+
+Useful for scripts and CI:
+
+```bash
+export ONESEARCH_URL=http://infra-stack:8000
+export ONESEARCH_TOKEN=xxxxx
+onesearch search "compose" --json
+```
+
+## Docker fallback
+
+If you prefer not to install the standalone package on a machine, you can still run the bundled CLI from the app container:
+
+```bash
+docker exec -it onesearch-app onesearch status
 ```
 
 See [CLI Overview](index.md#configuration) for details.

--- a/docs/cli/examples.md
+++ b/docs/cli/examples.md
@@ -2,14 +2,33 @@
 
 Real-world CLI automation scripts.
 
-!!! note "Coming Soon"
-    More examples coming soon.
+## Standalone CLI setup
 
-## Quick Examples
+```bash
+pipx install onesearch-cli
+onesearch config set backend_url http://infra-stack:8000
+onesearch login
+onesearch whoami
+```
 
-See [CLI Overview](index.md#scripting-examples) for sample scripts.
+## Scripted auth
 
-## Common Workflows
+```bash
+export ONESEARCH_URL=http://infra-stack:8000
+export ONESEARCH_TOKEN=xxxxx
+onesearch search "compose" --json
+```
+
+## Docker fallback
+
+The Docker image bundles the same CLI codebase as the standalone package for a given release version.
+
+```bash
+docker exec -it onesearch-app onesearch status
+docker exec -it onesearch-app onesearch search "compose"
+```
+
+## Common workflows
 
 - Automated reindexing with cron
 - Search and process results

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -1,6 +1,6 @@
 # CLI Overview
 
-The OneSearch command-line interface lets you manage sources, search documents, and automate workflows from the terminal.
+`onesearch-cli` is a standalone command-line client for a running OneSearch server. It talks to the same backend API as the web UI, so both interfaces share the same sources, indexes, auth, and search results. Tagged OneSearch releases publish the Docker image and the CLI package on the same shared version.
 
 ## Why Use the CLI
 
@@ -10,65 +10,51 @@ The OneSearch command-line interface lets you manage sources, search documents, 
 
 **JSON output**: Parse results programmatically with `--json`.
 
-**Speed**: Faster than clicking through the web UI once you know the commands.
+**Fast admin workflow**: Search, inspect status, and manage sources without opening the browser.
 
 ---
 
 ## Installation
 
-Install using pip:
+Install the standalone CLI with `pipx`:
 
 ```bash
-cd cli
-pip install -e .
+pipx install onesearch-cli
 ```
 
-Once published to PyPI, you'll be able to install with:
-
-```bash
-pip install onesearch-cli
-```
-
-See the [CLI Installation Guide](installation.md) for details.
+You still need a running OneSearch backend somewhere on your network. See the [CLI Installation Guide](installation.md) for details.
 
 ---
 
 ## Quick Start
 
-Configure the API endpoint:
+Point the CLI at your server, then log in:
 
 ```bash
-# Initialize config file
-onesearch config init
-
-# Set URL if not localhost
-onesearch config set url http://192.168.1.100:8000
-
-# Or use environment variable
-export ONESEARCH_URL=http://192.168.1.100:8000
+onesearch config set backend_url http://192.168.1.100:8000
+onesearch login
+onesearch whoami
 ```
 
 Basic commands:
 
 ```bash
-# Check connection
 onesearch health
-
-# Add a source
-onesearch source add "Documents" /data/docs --include "**/*.pdf,**/*.md"
-
-# List sources
 onesearch source list
-
-# Trigger indexing
-onesearch source reindex documents
-
-# Search
 onesearch search "kubernetes deployment"
-
-# Check status
 onesearch status
 ```
+
+### Docker fallback
+
+If you don't want to install the standalone CLI yet, the Docker image still includes it:
+
+```bash
+docker exec -it onesearch-app onesearch status
+docker exec -it onesearch-app onesearch whoami
+```
+
+That works fine for debugging, but the standalone CLI is the preferred path.
 
 ---
 
@@ -135,13 +121,13 @@ onesearch health
 onesearch config show
 
 # Get specific value
-onesearch config get url
+onesearch config get backend_url
 
 # Set value
-onesearch config set url http://localhost:8000
+onesearch config set backend_url http://localhost:8000
 
-# Initialize config file
-onesearch config init
+# Show config path
+onesearch config path
 ```
 
 ---
@@ -203,19 +189,18 @@ onesearch --url http://nas.local:8000 status
 
 The CLI stores config in a platform-specific location:
 
-- **Linux/macOS**: `~/.config/onesearch/config.json`
-- **Windows**: `%APPDATA%\onesearch\config.json`
+- **Linux/macOS**: `~/.config/onesearch/config.yml`
+- **Windows**: `%APPDATA%\onesearch\config.yml`
 
 Example config:
 
-```json
-{
-  "url": "http://localhost:8000",
-  "timeout": 30
-}
+```yaml
+backend_url: http://localhost:8000
+auth:
+  token: null
 ```
 
-You can override with the `ONESEARCH_URL` environment variable.
+You can override with `ONESEARCH_URL` and `ONESEARCH_TOKEN`.
 
 See the [Configuration Guide](configuration.md) for details.
 

--- a/docs/cli/installation.md
+++ b/docs/cli/installation.md
@@ -1,22 +1,37 @@
 # CLI Installation
 
-Install the OneSearch command-line interface.
+Install `onesearch-cli`, the standalone command-line client for a running OneSearch server.
 
-!!! note "Coming Soon"
-    Detailed installation guide coming soon.
+## Recommended: pipx
 
-## Quick Install
+```bash
+pipx install onesearch-cli
+```
+
+## Fallback: install from source
 
 ```bash
 cd cli
 pip install -e .
 ```
 
-## Configuration
+## Connect to your server
 
 ```bash
-onesearch config init
-onesearch config set url http://localhost:8000
+onesearch config set backend_url http://infra-stack:8000
+onesearch login
+onesearch whoami
+```
+
+The CLI does not ship its own backend, indexer, or search data. It connects to the same OneSearch server used by the web UI. Tagged releases keep the Docker image and `onesearch-cli` on the same version.
+
+## Docker fallback
+
+If you already have the app container running, you can use the bundled CLI without installing anything locally:
+
+```bash
+docker exec -it onesearch-app onesearch status
+docker exec -it onesearch-app onesearch whoami
 ```
 
 See [CLI Overview](index.md) for usage.

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -308,11 +308,12 @@ def main():
     print(f"  4. Commit all changed files")
     print(f"  5. Create and push tag {tag}")
     print(f"  6. Create GitHub release {tag}")
-    print(f"  -> Docker CI builds and pushes:")
+    print(f"  -> Shared release workflow publishes:")
     print(f"       ghcr.io/demigodmode/onesearch:{new_version}")
     print(f"       ghcr.io/demigodmode/onesearch:{new_version.rsplit('.', 1)[0]}")
     print(f"       ghcr.io/demigodmode/onesearch:latest")
-    print(f"       docker.io/demigodmode/onesearch (same tags)\n")
+    print(f"       docker.io/demigodmode/onesearch (same tags)")
+    print(f"       onesearch-cli=={new_version} (PyPI, if publishing is configured)\n")
 
     if not confirm("Proceed?"):
         sys.exit(0)
@@ -375,9 +376,10 @@ Done. {tag} is live.
   Actions (build): https://github.com/{REPO}/actions
   GHCR image:      ghcr.io/demigodmode/onesearch:{new_version}
   Docker Hub:      docker.io/demigodmode/onesearch:{new_version}
+  CLI package:     onesearch-cli=={new_version}
   Latest tags:     :{minor_tag}  :latest
 
-Docker build is running in CI — check Actions for progress.
+Shared release workflow is running in CI — check Actions for progress.
 """)
 
 


### PR DESCRIPTION
Standalone CLI flow is in much better shape now - login/logout/whoami, token auth for scripts, live startup banner, shared Docker + package release pipeline, and Python-level CLI integration tests.

Also cleaned up the docs so the install/release story is less confusing. Docker image and onesearch-cli now stay on the same versioned release path.

Refs #20