### PR TITLE
fix the broken release workflow conditions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -19,6 +19,10 @@ jobs:
     permissions:
       contents: read
       packages: write
+    env:
+      PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
     steps:
       - name: Checkout repository
@@ -45,10 +49,10 @@ jobs:
           path: cli/dist/*
 
       - name: Publish onesearch-cli to PyPI
-        if: github.event_name == 'release' && secrets.PYPI_API_TOKEN != ''
+        if: github.event_name == 'release' && env.PYPI_API_TOKEN != ''
         env:
           TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+          TWINE_PASSWORD: ${{ env.PYPI_API_TOKEN }}
         run: |
           uv run --with twine python -m twine upload cli/dist/*
 
@@ -63,12 +67,12 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Log in to Docker Hub
-        if: secrets.DOCKERHUB_USERNAME != '' && secrets.DOCKERHUB_TOKEN != ''
+        if: env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != ''
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY_DOCKER }}
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ env.DOCKERHUB_TOKEN }}
 
       - name: Extract GHCR metadata (tags, labels)
         id: meta-ghcr
@@ -84,7 +88,7 @@ jobs:
             type=raw,value=manual,enable=${{ github.event_name == 'workflow_dispatch' }}
 
       - name: Extract Docker Hub metadata (tags, labels)
-        if: secrets.DOCKERHUB_USERNAME != '' && secrets.DOCKERHUB_TOKEN != ''
+        if: env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != ''
         id: meta-dockerhub
         uses: docker/metadata-action@v5
         with:


### PR DESCRIPTION
GitHub was rejecting the release workflow before any jobs started because it was using secrets directly in step if conditions. Moved those checks through job env vars so the workflow can actually start again.