### PR TITLE
Add opt-in managed Meilisearch mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,8 +10,9 @@ DATABASE_URL=sqlite:////app/data/onesearch.db
 # Leave this as-is for the default external Meilisearch compose setup.
 MEILI_URL=http://meilisearch:7700
 
-# Experimental: run Meilisearch inside the OneSearch container instead of using
-# the separate meilisearch service. Use docker-compose.managed-meili.yml for this.
+# Experimental/opt-in: run Meilisearch inside the OneSearch container instead
+# of using the separate meilisearch service. Use docker-compose.managed-meili.yml
+# for this; existing two-container installs should leave it disabled.
 # ONESEARCH_MANAGED_MEILI=false
 
 # Logging

--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,12 @@ MEILI_MASTER_KEY=your-secure-master-key-here
 DATABASE_URL=sqlite:////app/data/onesearch.db
 
 # Meilisearch URL (internal Docker network)
+# Leave this as-is for the default external Meilisearch compose setup.
 MEILI_URL=http://meilisearch:7700
+
+# Experimental: run Meilisearch inside the OneSearch container instead of using
+# the separate meilisearch service. Use docker-compose.managed-meili.yml for this.
+# ONESEARCH_MANAGED_MEILI=false
 
 # Logging
 LOG_LEVEL=INFO

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -18,6 +18,20 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
+    services:
+      meilisearch:
+        image: getmeili/meilisearch:v1.12
+        ports:
+          - 7700:7700
+        env:
+          MEILI_MASTER_KEY: test-master-key
+          MEILI_ENV: development
+        options: >-
+          --health-cmd="wget --no-verbose --spider http://127.0.0.1:7700/health || exit 1"
+          --health-interval=5s
+          --health-timeout=5s
+          --health-retries=12
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -47,6 +61,9 @@ jobs:
           uv sync --all-extras --all-groups
 
       - name: Run backend tests
+        env:
+          MEILI_URL: http://127.0.0.1:7700
+          MEILI_MASTER_KEY: test-master-key
         run: |
           uv run pytest backend/tests/ -v --tb=short --color=yes --cov=app --cov-report=xml
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to OneSearch will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Managed Meilisearch mode** - added an opt-in single-container mode where OneSearch starts Meilisearch inside the app container. Existing two-container installs keep working as before.
+- **Meilisearch contract coverage** - added a live integration test against Meilisearch v1.12 so client/API mismatches are caught earlier.
+
+### Fixed
+
+- **Source cleanup in Meilisearch** - replaced the unsupported delete-by-filter client call with the supported `delete_documents(..., filter=...)` API.
+- **Bundled Meilisearch on ARM64** - fixed the Dockerfile so the bundled Meilisearch binary works on both amd64 and ARM64 builds.
+
+---
+
 ## [0.12.1] - 2026-04-23
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Managed Meilisearch mode** - added an opt-in single-container mode where OneSearch starts Meilisearch inside the app container. Existing two-container installs keep working as before.
+- **Managed Meilisearch mode** - added an opt-in single-container mode where OneSearch starts Meilisearch inside the app container. Existing two-container installs keep working as before, and the docs now include a safe migration guide.
 - **Meilisearch contract coverage** - added a live integration test against Meilisearch v1.12 so client/API mismatches are caught earlier.
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,9 +75,9 @@ COPY --from=backend-builder /usr/local/bin /usr/local/bin
 
 # Copy Meilisearch binary and Alpine runtime libs for opt-in managed mode
 COPY --from=meilisearch-runtime /bin/meilisearch /usr/local/bin/meilisearch
-COPY --from=meilisearch-runtime /lib/ld-musl-x86_64.so.1 /lib/ld-musl-x86_64.so.1
+COPY --from=meilisearch-runtime /lib/ld-musl-*.so.1 /lib/
+COPY --from=meilisearch-runtime /lib/libc.musl-*.so.1 /lib/
 COPY --from=meilisearch-runtime /usr/lib/libgcc_s.so.1 /usr/lib/libgcc_s.so.1
-RUN ln -sf ld-musl-x86_64.so.1 /lib/libc.musl-x86_64.so.1
 
 # Copy backend application code
 COPY --chown=onesearch:onesearch backend/ ./backend/

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,12 @@ COPY cli/ ./cli/
 RUN uv pip install --system ./backend ./cli
 
 # =============================================================================
-# Stage 3: Runtime
+# Stage 3: Meilisearch binary
+# =============================================================================
+FROM getmeili/meilisearch:v1.12 AS meilisearch-runtime
+
+# =============================================================================
+# Stage 4: Runtime
 # =============================================================================
 FROM python:3.13-slim
 
@@ -68,6 +73,12 @@ WORKDIR /app
 COPY --from=backend-builder /usr/local/lib/python3.13/site-packages /usr/local/lib/python3.13/site-packages
 COPY --from=backend-builder /usr/local/bin /usr/local/bin
 
+# Copy Meilisearch binary and Alpine runtime libs for opt-in managed mode
+COPY --from=meilisearch-runtime /bin/meilisearch /usr/local/bin/meilisearch
+COPY --from=meilisearch-runtime /lib/ld-musl-x86_64.so.1 /lib/ld-musl-x86_64.so.1
+COPY --from=meilisearch-runtime /usr/lib/libgcc_s.so.1 /usr/lib/libgcc_s.so.1
+RUN ln -sf ld-musl-x86_64.so.1 /lib/libc.musl-x86_64.so.1
+
 # Copy backend application code
 COPY --chown=onesearch:onesearch backend/ ./backend/
 
@@ -78,9 +89,10 @@ COPY --from=frontend-builder /app/dist ./frontend/
 COPY nginx.conf /etc/nginx/nginx.conf
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
-# Copy and set up entrypoint script
+# Copy and set up runtime scripts
 COPY entrypoint.sh /app/entrypoint.sh
-RUN chmod +x /app/entrypoint.sh
+COPY start-backend.sh /app/start-backend.sh
+RUN chmod +x /app/entrypoint.sh /app/start-backend.sh
 
 # Fix nginx permissions (Debian uses www-data, not nginx)
 RUN mkdir -p /var/cache/nginx /var/log/nginx && \
@@ -89,8 +101,8 @@ RUN mkdir -p /var/cache/nginx /var/log/nginx && \
     touch /var/run/nginx.pid && \
     chown -R www-data:www-data /var/run/nginx.pid
 
-# Create data directory with correct permissions
-RUN mkdir -p /app/data && chown -R onesearch:onesearch /app/data
+# Create data directories with correct permissions
+RUN mkdir -p /app/data /app/meili_data && chown -R onesearch:onesearch /app/data /app/meili_data
 
 # Expose port (nginx listens on 8000)
 EXPOSE 8000

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ docker-compose up -d
 
 Open http://localhost:8000, run through the setup wizard, add a directory as a source, and start searching.
 
-> **Heads up:** OneSearch is moving toward an easier single-container setup. The default install still runs Meilisearch as a separate container, but v0.13 adds an opt-in managed Meilisearch mode where OneSearch starts Meilisearch inside the app container. If you want to try it, use `docker-compose.managed-meili.yml`. Existing installs do not need to change.
+> **Heads up:** OneSearch is moving toward an easier single-container setup. The default install still runs Meilisearch as a separate container, but v0.13 adds an opt-in managed Meilisearch mode where OneSearch starts Meilisearch inside the app container. If you want to try it, use `docker-compose.managed-meili.yml`; existing installs should read the [migration guide](https://onesearch.readthedocs.io/en/latest/getting-started/migrate-to-managed-meilisearch/) first. Existing installs do not need to change.
 
 Full setup guide: [onesearch.readthedocs.io](https://onesearch.readthedocs.io/en/latest/getting-started/installation/)
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ docker-compose up -d
 
 Open http://localhost:8000, run through the setup wizard, add a directory as a source, and start searching.
 
+> **Heads up:** OneSearch is moving toward an easier single-container setup. The default install still runs Meilisearch as a separate container, but v0.13 adds an opt-in managed Meilisearch mode where OneSearch starts Meilisearch inside the app container. If you want to try it, use `docker-compose.managed-meili.yml`. Existing installs do not need to change.
+
 Full setup guide: [onesearch.readthedocs.io](https://onesearch.readthedocs.io/en/latest/getting-started/installation/)
 
 ---

--- a/backend/app/api/sources.py
+++ b/backend/app/api/sources.py
@@ -330,12 +330,13 @@ async def reindex_source(
     try:
         from starlette.concurrency import run_in_threadpool
         from sqlalchemy.orm import sessionmaker
-        from ..db.database import engine
+
+        db_bind = db.get_bind()
 
         def sync_index_wrapper():
             import asyncio
 
-            SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+            SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=db_bind)
             thread_db = SessionLocal()
 
             try:

--- a/backend/app/container/__init__.py
+++ b/backend/app/container/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (C) 2026 demigodmode
+# SPDX-License-Identifier: AGPL-3.0-only

--- a/backend/app/container/supervisord.py
+++ b/backend/app/container/supervisord.py
@@ -1,0 +1,87 @@
+# Copyright (C) 2026 demigodmode
+# SPDX-License-Identifier: AGPL-3.0-only
+
+"""Render supervisord config for the unified container."""
+import os
+
+BASE_CONFIG = """# Copyright (C) 2025 demigodmode
+# SPDX-License-Identifier: AGPL-3.0-only
+
+[supervisord]
+nodaemon=true
+user=root
+logfile=/var/log/supervisor/supervisord.log
+pidfile=/var/run/supervisord.pid
+loglevel=info
+
+[program:nginx]
+command=/usr/sbin/nginx -g "daemon off;"
+autostart=true
+autorestart=true
+priority=10
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+
+{meilisearch_program}
+[program:uvicorn]
+command=/app/start-backend.sh
+directory=/app/backend
+user=onesearch
+autostart=true
+autorestart=true
+priority=20
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+environment={uvicorn_environment}
+"""
+
+MEILISEARCH_COMMAND = " ".join([
+    "/usr/local/bin/meilisearch",
+    "--db-path /app/meili_data",
+    "--http-addr 127.0.0.1:7700",
+])
+
+MEILISEARCH_PROGRAM = f"""[program:meilisearch]
+command={MEILISEARCH_COMMAND}
+user=onesearch
+autostart=true
+autorestart=true
+priority=15
+environment=MEILI_MASTER_KEY="%(ENV_MEILI_MASTER_KEY)s",MEILI_ENV="production",MEILI_NO_ANALYTICS="true"
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+
+"""
+
+
+def render_supervisord_config(managed_meili: bool) -> str:
+    """Return supervisord config for external or managed Meilisearch mode."""
+    environment = ['PATH="/home/onesearch/.local/bin:%(ENV_PATH)s"']
+    meilisearch_program = ""
+
+    if managed_meili:
+        meilisearch_program = MEILISEARCH_PROGRAM
+        environment.extend([
+            'MEILI_URL="http://127.0.0.1:7700"',
+            'MEILI_MASTER_KEY="%(ENV_MEILI_MASTER_KEY)s"',
+        ])
+
+    return BASE_CONFIG.format(
+        meilisearch_program=meilisearch_program,
+        uvicorn_environment=",".join(environment),
+    )
+
+
+if __name__ == "__main__":
+    print(
+        render_supervisord_config(
+            os.environ.get("ONESEARCH_MANAGED_MEILI", "false").lower() == "true"
+        ),
+        end="",
+    )

--- a/backend/app/services/search.py
+++ b/backend/app/services/search.py
@@ -206,7 +206,7 @@ class MeilisearchService:
         try:
             # Run blocking HTTP call in thread pool
             task = await asyncio.to_thread(
-                self.index.delete_documents_by_filter, filter_str
+                self.index.delete_documents, filter=filter_str
             )
             logger.info(f"Deleted documents with filter: {filter_str}")
             return task.__dict__

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -515,6 +515,24 @@ class TestReindexEndpoint:
         assert response.status_code == 404
         assert "not found" in response.json()["detail"].lower()
 
+    def test_reindex_uses_overridden_database_session(self, client, sample_source, monkeypatch):
+        """Reindexing should use the test database bind, not the app's default DB."""
+        from app.api import sources
+
+        class FakeSearchService:
+            async def index_documents(self, documents):
+                return None
+
+            async def delete_documents_by_filter(self, filter_str):
+                return None
+
+        monkeypatch.setattr(sources, "meili_service", FakeSearchService())
+
+        response = client.post(f"/api/sources/{sample_source.id}/reindex")
+
+        assert response.status_code == 200, \
+            f"Expected 200, got {response.status_code}: {response.json()}"
+
     @pytest.mark.asyncio
     async def test_reindex_source_success(self, client, sample_source, meili_available):
         """Test reindexing returns statistics

--- a/backend/tests/test_meilisearch_integration.py
+++ b/backend/tests/test_meilisearch_integration.py
@@ -1,0 +1,151 @@
+# Copyright (C) 2026 demigodmode
+# SPDX-License-Identifier: AGPL-3.0-only
+
+"""
+Live Meilisearch contract tests.
+
+These tests are skipped unless a Meilisearch server is reachable. CI starts one so
+we catch client/server API mismatches that mocked tests can miss.
+"""
+import json
+import os
+import uuid
+
+import pytest
+from meilisearch import Client
+
+from app.services.search import (
+    FILTERABLE_FIELDS,
+    SEARCHABLE_FIELDS,
+    SORTABLE_FIELDS,
+    MeilisearchService,
+)
+
+
+RANKING_RULES = [
+    "words",
+    "typo",
+    "proximity",
+    "attribute",
+    "sort",
+    "exactness",
+]
+
+
+@pytest.fixture(scope="session")
+def live_meili_client():
+    url = os.environ.get("MEILI_URL", "http://localhost:7700")
+    key = os.environ.get("MEILI_MASTER_KEY", "")
+    client = Client(url, key)
+
+    try:
+        client.health()
+    except Exception as exc:
+        pytest.skip(f"Meilisearch is not available at {url}: {exc}")
+
+    return client
+
+
+@pytest.fixture
+def live_index(live_meili_client):
+    index_name = f"onesearch_test_{uuid.uuid4().hex}"
+    task = live_meili_client.create_index(index_name, {"primaryKey": "id"})
+    live_meili_client.wait_for_task(task.task_uid, timeout_in_ms=30000)
+
+    index = live_meili_client.get_index(index_name)
+    try:
+        yield index
+    finally:
+        task = live_meili_client.delete_index(index_name)
+        live_meili_client.wait_for_task(task.task_uid, timeout_in_ms=30000)
+
+
+def wait_for_task_from_dict(client: Client, task: dict):
+    task_uid = task.get("task_uid") or task.get("taskUid")
+    client.wait_for_task(task_uid, timeout_in_ms=30000)
+
+
+def document_id(document):
+    return document["id"] if isinstance(document, dict) else document.id
+
+
+@pytest.mark.asyncio
+async def test_onesearch_meilisearch_contract(live_meili_client, live_index):
+    service = MeilisearchService()
+    service.client = live_meili_client
+    service.index = live_index
+
+    for task in (
+        live_index.update_searchable_attributes(SEARCHABLE_FIELDS),
+        live_index.update_filterable_attributes(FILTERABLE_FIELDS),
+        live_index.update_sortable_attributes(SORTABLE_FIELDS),
+        live_index.update_ranking_rules(RANKING_RULES),
+    ):
+        live_meili_client.wait_for_task(task.task_uid, timeout_in_ms=30000)
+
+    add_task = await service.index_documents([
+        {
+            "id": "doc-a",
+            "source_id": "source-a",
+            "source_name": "Source A",
+            "path": "/data/source-a/readme.md",
+            "basename": "readme.md",
+            "title": "Readme",
+            "content": "OneSearch test document about homelab search",
+            "type": "markdown",
+            "extension": "md",
+            "size_bytes": 100,
+            "modified_at": 20,
+            "indexed_at": "2026-04-27T00:00:00Z",
+            "metadata": {},
+        },
+        {
+            "id": "doc-b",
+            "source_id": "source-b",
+            "source_name": "Source B",
+            "path": "/data/source-b/notes.txt",
+            "basename": "notes.txt",
+            "title": "Notes",
+            "content": "Another test document for filter cleanup",
+            "type": "text",
+            "extension": "txt",
+            "size_bytes": 200,
+            "modified_at": 10,
+            "indexed_at": "2026-04-27T00:00:00Z",
+            "metadata": {},
+        },
+    ])
+    wait_for_task_from_dict(live_meili_client, add_task)
+
+    basic = await service.search("test", limit=10)
+    assert basic["estimatedTotalHits"] == 2
+    assert basic["hits"][0]["id"] in {"doc-a", "doc-b"}
+    assert "_formatted" in basic["hits"][0]
+
+    source_filtered = await service.search(
+        "test",
+        filters=[f"source_id = {json.dumps('source-a')}"],
+        limit=10,
+    )
+    assert [hit["id"] for hit in source_filtered["hits"]] == ["doc-a"]
+
+    type_filtered = await service.search(
+        "test",
+        filters=[f"type = {json.dumps('text')}"],
+        limit=10,
+    )
+    assert [hit["id"] for hit in type_filtered["hits"]] == ["doc-b"]
+
+    sorted_results = await service.search("test", sort="modified_at:desc", limit=10)
+    assert [hit["id"] for hit in sorted_results["hits"]] == ["doc-a", "doc-b"]
+
+    document = await service.get_document("doc-a")
+    assert document_id(document) == "doc-a"
+
+    delete_task = await service.delete_documents_by_filter(
+        f"source_id = {json.dumps('source-a')}"
+    )
+    wait_for_task_from_dict(live_meili_client, delete_task)
+
+    after_delete = await service.search("test", limit=10)
+    assert [hit["id"] for hit in after_delete["hits"]] == ["doc-b"]

--- a/backend/tests/test_search_service.py
+++ b/backend/tests/test_search_service.py
@@ -165,13 +165,22 @@ class TestDeleteDocument:
 class TestDeleteDocumentsByFilter:
 
     @pytest.mark.asyncio
-    async def test_delete_by_filter_success(self, connected_service):
-        task = _fake_task(task_uid=6)
-        connected_service.index.delete_documents_by_filter.return_value = task
+    async def test_delete_by_filter_uses_supported_client_method(self, service):
+        class FakeIndex:
+            def __init__(self):
+                self.filter = None
 
-        result = await connected_service.delete_documents_by_filter("source_id = 'src1'")
+            def delete_documents(self, *, filter):
+                self.filter = filter
+                return _fake_task(task_uid=6)
+
+        fake_index = FakeIndex()
+        service.index = fake_index
+
+        result = await service.delete_documents_by_filter("source_id = 'src1'")
 
         assert result["task_uid"] == 6
+        assert fake_index.filter == "source_id = 'src1'"
 
     @pytest.mark.asyncio
     async def test_delete_by_filter_not_initialized(self, service):

--- a/backend/tests/test_supervisord_config.py
+++ b/backend/tests/test_supervisord_config.py
@@ -1,0 +1,25 @@
+# Copyright (C) 2026 demigodmode
+# SPDX-License-Identifier: AGPL-3.0-only
+
+"""Tests for container supervisor config rendering."""
+
+from app.container.supervisord import render_supervisord_config
+
+
+def test_managed_meili_config_starts_meilisearch_and_points_api_at_localhost():
+    config = render_supervisord_config(managed_meili=True)
+
+    assert "[program:meilisearch]" in config
+    assert "command=/usr/local/bin/meilisearch --db-path /app/meili_data" in config
+    assert "--master-key" not in config
+    assert "MEILI_URL=\"http://127.0.0.1:7700\"" in config
+    assert "MEILI_MASTER_KEY=\"%(ENV_MEILI_MASTER_KEY)s\"" in config
+    assert "MEILI_ENV=\"production\"" in config
+    assert "command=/app/start-backend.sh" in config
+
+
+def test_external_meili_config_does_not_start_meilisearch():
+    config = render_supervisord_config(managed_meili=False)
+
+    assert "[program:meilisearch]" not in config
+    assert "MEILI_URL=\"http://127.0.0.1:7700\"" not in config

--- a/docker-compose.managed-meili.yml
+++ b/docker-compose.managed-meili.yml
@@ -6,8 +6,8 @@ services:
       context: .
       dockerfile: Dockerfile
 
-    # For production testing with a pre-built candidate image, replace build with:
-    # image: ghcr.io/demigodmode/onesearch:meili-managed-candidate
+    # For a released image, replace build with:
+    # image: ghcr.io/demigodmode/onesearch:latest
 
     container_name: onesearch-app
     volumes:

--- a/docker-compose.managed-meili.yml
+++ b/docker-compose.managed-meili.yml
@@ -1,0 +1,44 @@
+services:
+  # OneSearch with managed Meilisearch inside the app container.
+  # Experimental/opt-in while bundled search backend support is validated.
+  onesearch:
+    build:
+      context: .
+      dockerfile: Dockerfile
+
+    # For production testing with a pre-built candidate image, replace build with:
+    # image: ghcr.io/demigodmode/onesearch:meili-managed-candidate
+
+    container_name: onesearch-app
+    volumes:
+      # Persistent SQLite database
+      - onesearch_data:/app/data
+
+      # Persistent managed Meilisearch index data
+      - onesearch_index:/app/meili_data
+
+      # Example source mounts (uncomment and modify as needed)
+      # - /mnt/nas/documents:/data/nas_docs:ro
+      # - /home/user/Documents:/data/documents:ro
+
+    environment:
+      - ONESEARCH_MANAGED_MEILI=true
+      - MEILI_MASTER_KEY=${MEILI_MASTER_KEY}
+      - SESSION_SECRET=${SESSION_SECRET}
+      - DATABASE_URL=sqlite:////app/data/onesearch.db
+      - LOG_LEVEL=${LOG_LEVEL:-INFO}
+    ports:
+      - "8000:8000"
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:8000/api/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+
+volumes:
+  onesearch_data:
+    driver: local
+  onesearch_index:
+    driver: local

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -119,6 +119,26 @@ docker-compose logs -f onesearch
 
 Open http://localhost:8000 in your browser. You should see the OneSearch search page.
 
+### Optional: managed Meilisearch mode
+
+The default compose file runs Meilisearch as a separate container. That is still the recommended path for most installs.
+
+There is also an opt-in managed mode where OneSearch starts Meilisearch inside the app container. It's useful if you want a single app container and don't want to manage a separate Meilisearch service. Existing installs do not need to switch.
+
+To try it, download the managed compose file instead:
+
+```bash
+curl -O https://raw.githubusercontent.com/demigodmode/OneSearch/main/docker-compose.managed-meili.yml
+```
+
+Then start with:
+
+```bash
+docker-compose -f docker-compose.managed-meili.yml up -d
+```
+
+Managed mode still needs `MEILI_MASTER_KEY` in `.env`. It stores the SQLite database in `/app/data` and the bundled Meilisearch index in `/app/meili_data`, so keep both volumes if you want data to survive restarts.
+
 ---
 
 ## Option 2: Build from Source
@@ -184,6 +204,7 @@ After installation you have:
 - Web UI at http://localhost:8000
 - Backend API at http://localhost:8000/api
 - CLI tool (inside the container, or install separately)
+- Meilisearch, either as a separate container or inside the OneSearch container if managed mode is enabled
 
 ---
 
@@ -210,7 +231,7 @@ docker-compose down -v
 
 # Remove images
 docker rmi ghcr.io/demigodmode/onesearch:latest
-docker rmi meilisearch/meilisearch:latest
+docker rmi getmeili/meilisearch:v1.12
 ```
 
 The `-v` flag deletes your search index and configurations. Your original files are never modified or deleted by OneSearch.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -137,7 +137,7 @@ Then start with:
 docker-compose -f docker-compose.managed-meili.yml up -d
 ```
 
-Managed mode still needs `MEILI_MASTER_KEY` in `.env`. It stores the SQLite database in `/app/data` and the bundled Meilisearch index in `/app/meili_data`, so keep both volumes if you want data to survive restarts.
+Managed mode still needs `MEILI_MASTER_KEY` in `.env`. It stores the SQLite database in `/app/data` and the bundled Meilisearch index in `/app/meili_data`, so keep both volumes if you want data to survive restarts. If you're switching an existing install, read [Migrating to managed Meilisearch](migrate-to-managed-meilisearch.md) first.
 
 ---
 

--- a/docs/getting-started/migrate-to-managed-meilisearch.md
+++ b/docs/getting-started/migrate-to-managed-meilisearch.md
@@ -1,0 +1,166 @@
+# Migrating to managed Meilisearch
+
+Managed Meilisearch runs the search engine inside the OneSearch app container. The regular two-container setup still works, so there is no rush to switch existing installs.
+
+Use this guide if you want to try the managed mode introduced in v0.13.
+
+## Before you start
+
+A few things to know:
+
+- Keep your original source files exactly where they are.
+- Keep your OneSearch data volume. This contains the SQLite database and source configuration.
+- The Meilisearch index is rebuildable. If you switch modes, plan on reindexing your sources.
+- External Meilisearch remains supported. You can roll back to the two-container compose file if needed.
+
+## 1. Back up the current install
+
+From the directory with your current `docker-compose.yml` and `.env`:
+
+```bash
+docker-compose down
+```
+
+Back up the compose/env files:
+
+```bash
+cp docker-compose.yml docker-compose.external-meili.backup.yml
+cp .env .env.backup
+```
+
+Back up named volumes if you use Docker volumes. The exact names depend on your compose project name, but these are common for the default setup:
+
+```bash
+docker volume ls | grep onesearch
+```
+
+At minimum, preserve the OneSearch app data volume mounted at `/app/data`. That is where the SQLite database lives.
+
+If you want a simple archive backup and your volume is named `onesearch_onesearch_data`:
+
+```bash
+docker run --rm \
+  -v onesearch_onesearch_data:/data:ro \
+  -v "$PWD":/backup \
+  alpine \
+  tar -czf /backup/onesearch-data-backup.tar.gz -C /data .
+```
+
+You can also back up the old Meilisearch volume if you want to keep it around, but managed mode does not reuse the external container's `/meili_data` volume directly.
+
+## 2. Download the managed compose file
+
+```bash
+curl -O https://raw.githubusercontent.com/demigodmode/OneSearch/main/docker-compose.managed-meili.yml
+```
+
+If you are running from a git checkout, the file is already in the repo.
+
+## 3. Check `.env`
+
+Make sure `.env` has these values set:
+
+```env
+MEILI_MASTER_KEY=your-secure-master-key-here
+SESSION_SECRET=your-session-secret-key-here
+DATABASE_URL=sqlite:////app/data/onesearch.db
+```
+
+You do not need to set `MEILI_URL` for managed mode. The app points itself at the bundled Meilisearch process.
+
+## 4. Carry over source mounts
+
+If your old `docker-compose.yml` had source mounts like this:
+
+```yaml
+volumes:
+  - onesearch_data:/app/data
+  - /mnt/nas/documents:/data/documents:ro
+```
+
+copy the source mounts into the `onesearch` service in `docker-compose.managed-meili.yml`:
+
+```yaml
+volumes:
+  - onesearch_data:/app/data
+  - onesearch_index:/app/meili_data
+  - /mnt/nas/documents:/data/documents:ro
+```
+
+Keep source mounts read-only unless you have a specific reason not to.
+
+## 5. Start managed mode
+
+```bash
+docker-compose -f docker-compose.managed-meili.yml up -d
+```
+
+Check the container status:
+
+```bash
+docker-compose -f docker-compose.managed-meili.yml ps
+```
+
+Follow logs during the first start:
+
+```bash
+docker-compose -f docker-compose.managed-meili.yml logs -f onesearch
+```
+
+You should see OneSearch start, then managed Meilisearch become ready.
+
+## 6. Verify the app
+
+Open:
+
+```text
+http://localhost:8000
+```
+
+Or check health from the host:
+
+```bash
+curl http://localhost:8000/api/health
+```
+
+The health response should show Meilisearch as available.
+
+## 7. Reindex sources
+
+After switching modes, reindex your sources from the admin UI. The source configuration is kept in OneSearch's database, but the managed Meilisearch index starts with its own `/app/meili_data` volume.
+
+Large source trees may take a while to rebuild. Your original files are not modified.
+
+## Rolling back
+
+If managed mode does not work for your setup:
+
+```bash
+docker-compose -f docker-compose.managed-meili.yml down
+```
+
+Start the previous two-container setup again:
+
+```bash
+docker-compose -f docker-compose.external-meili.backup.yml up -d
+```
+
+If you did not change your old Meilisearch volume, the external setup should come back with the old index data.
+
+## Cleaning up old Meilisearch data
+
+Do not delete the old external Meilisearch volume until you are happy with managed mode and have confirmed search works after a restart.
+
+When you are ready, find the old volume:
+
+```bash
+docker volume ls | grep meili
+```
+
+Then remove the old external Meilisearch volume by name:
+
+```bash
+docker volume rm <old-meilisearch-volume-name>
+```
+
+Do not remove the OneSearch data volume mounted at `/app/data` unless you want to reset the app.

--- a/docs/getting-started/upgrading.md
+++ b/docs/getting-started/upgrading.md
@@ -69,7 +69,7 @@ If you switch to `docker-compose.managed-meili.yml`, OneSearch runs Meilisearch 
 - `/app/data` for the SQLite database
 - `/app/meili_data` for the bundled Meilisearch index
 
-The search index is derived from your configured sources, so it can be rebuilt if needed. The source files and OneSearch database are the important data to preserve.
+The search index is derived from your configured sources, so it can be rebuilt if needed. The source files and OneSearch database are the important data to preserve. For the step-by-step flow, see [Migrating to managed Meilisearch](migrate-to-managed-meilisearch.md).
 
 ---
 

--- a/docs/getting-started/upgrading.md
+++ b/docs/getting-started/upgrading.md
@@ -60,6 +60,19 @@ You can pin to specific tags if you want more control:
 
 ---
 
+## Managed Meilisearch mode
+
+Managed Meilisearch is opt-in. Upgrading does not change existing two-container installs; if your compose file has a separate `meilisearch` service, it will keep working that way.
+
+If you switch to `docker-compose.managed-meili.yml`, OneSearch runs Meilisearch inside the app container and points the backend at `http://127.0.0.1:7700`. Keep these volumes around:
+
+- `/app/data` for the SQLite database
+- `/app/meili_data` for the bundled Meilisearch index
+
+The search index is derived from your configured sources, so it can be rebuilt if needed. The source files and OneSearch database are the important data to preserve.
+
+---
+
 ## Version-Specific Notes
 
 Check the [Changelog](../about/changelog.md) for breaking changes and migration notes.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,9 +6,24 @@ set -e
 
 echo "Starting OneSearch..."
 
-# Ensure data directory is owned by onesearch user
+# Ensure data directories are owned by onesearch user
 # (Docker volumes may be root-owned on first create or upgrades)
 chown -R onesearch:onesearch /app/data 2>/dev/null || true
+
+if [ "${ONESEARCH_MANAGED_MEILI:-false}" = "true" ]; then
+    if [ -z "${MEILI_MASTER_KEY:-}" ]; then
+        echo "MEILI_MASTER_KEY is required when ONESEARCH_MANAGED_MEILI=true" >&2
+        exit 1
+    fi
+
+    echo "Managed Meilisearch enabled"
+    mkdir -p /app/meili_data
+    chown -R onesearch:onesearch /app/meili_data 2>/dev/null || true
+    export MEILI_URL="http://127.0.0.1:7700"
+fi
+
+# Render supervisord config for the selected search backend mode
+python -m app.container.supervisord > /etc/supervisor/conf.d/supervisord.conf
 
 # Run database migrations as onesearch user
 echo "Running database migrations..."

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,6 +78,7 @@ nav:
     - Installation: getting-started/installation.md
     - First-Time Setup: getting-started/first-time-setup.md
     - Upgrading: getting-started/upgrading.md
+    - Migrating to managed Meilisearch: getting-started/migrate-to-managed-meilisearch.md
   - User Guide:
     - Overview: user-guide/index.md
     - Adding Sources: user-guide/adding-sources.md

--- a/start-backend.sh
+++ b/start-backend.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Copyright (C) 2026 demigodmode
+# SPDX-License-Identifier: AGPL-3.0-only
+
+set -e
+
+if [ "${ONESEARCH_MANAGED_MEILI:-false}" = "true" ]; then
+    echo "Waiting for managed Meilisearch..."
+    for attempt in $(seq 1 60); do
+        if curl -fsS http://127.0.0.1:7700/health >/dev/null; then
+            echo "Managed Meilisearch is ready"
+            break
+        fi
+
+        if [ "$attempt" = "60" ]; then
+            echo "Managed Meilisearch did not become ready in time" >&2
+            exit 1
+        fi
+
+        sleep 1
+    done
+fi
+
+exec /usr/local/bin/uvicorn app.main:app --host 127.0.0.1 --port 8001


### PR DESCRIPTION
Adds opt-in managed Meilisearch mode.\n\nDefault docker-compose still uses external Meili, so existing installs keep working. New `docker-compose.managed-meili.yml` runs Meili inside the app container for folks who want to try the single-container path.\n\nAlso fixed the Meili delete-by-filter client mismatch and added a live Meili contract test so that kind of thing gets caught earlier.\n\nDocs include install/upgrade notes and a migration guide.