### PR TITLE
Cache-bust the new favicon

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,7 +2,7 @@
 <html lang="en" class="dark">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="icon" type="image/svg+xml" href="/onesearch-logo.svg?v=0.13.2" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>OneSearch - Self-hosted Search</title>
     <meta name="description" content="Fast, privacy-focused search for your homelab" />


### PR DESCRIPTION
Browsers cache favicons aggressively, so some installs kept showing the old tab icon even after the logo update.

This points the favicon link at the new logo asset with a versioned query string.

Checked with:
- npm run lint
- npm run build