### PR TITLE
Add full reindex migration tooling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to OneSearch will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Added full reindex support to the CLI and Admin Sources UI for managed Meilisearch migrations or index repair.
+
+### Fixed
+
+- Full reindex now validates that the source path exists before clearing existing index metadata.
+
+### Changed
+
+- Updated managed Meilisearch migration docs to require full reindexing after cutover.
+
+---
+
 ## [0.13.2] - 2026-05-06
 
 ### Fixed

--- a/backend/app/services/indexer.py
+++ b/backend/app/services/indexer.py
@@ -108,6 +108,12 @@ class IndexingService:
         stats = IndexingStats()
         total_bytes_processed = 0  # Track bytes for throughput metrics
 
+        root_path = Path(source.root_path)
+        if not root_path.exists():
+            raise FileNotFoundError(f"Root path does not exist: {source.root_path}")
+        if not root_path.is_dir():
+            raise ValueError(f"Root path is not a directory: {source.root_path}")
+
         # Full reindex: clear existing documents to handle migration or fix corruption
         if full:
             try:

--- a/backend/tests/test_indexer.py
+++ b/backend/tests/test_indexer.py
@@ -309,6 +309,36 @@ class TestIndexingService:
         assert indexed_file.size_bytes == 0
 
     @pytest.mark.asyncio
+    async def test_full_reindex_missing_root_does_not_clear_existing_index_state(self, db_session, mock_search_service):
+        """Full reindex should fail before clearing data when the source path is missing."""
+        source = Source(
+            id="missing_source",
+            name="Missing Source",
+            root_path="/definitely/missing/onesearch/path",
+            include_patterns=json.dumps(["**/*.txt"]),
+            exclude_patterns=json.dumps([]),
+        )
+        indexed_file = IndexedFile(
+            source_id="missing_source",
+            path="/definitely/missing/onesearch/path/file.txt",
+            size_bytes=100,
+            modified_at=datetime.now(timezone.utc).replace(tzinfo=None),
+            indexed_at=datetime.now(timezone.utc).replace(tzinfo=None),
+            status="success",
+        )
+        db_session.add_all([source, indexed_file])
+        db_session.commit()
+
+        service = IndexingService(db_session, mock_search_service)
+
+        with pytest.raises(FileNotFoundError):
+            await service.index_source("missing_source", full=True)
+
+        mock_search_service.delete_documents_by_filter.assert_not_called()
+        remaining = db_session.query(IndexedFile).filter_by(source_id="missing_source").count()
+        assert remaining == 1
+
+    @pytest.mark.asyncio
     @patch('app.services.indexer.FileScanner')
     async def test_index_source_full_flow(
         self,

--- a/cli/onesearch/api.py
+++ b/cli/onesearch/api.py
@@ -203,16 +203,18 @@ class OneSearchAPI:
         """Delete a source."""
         self._request("DELETE", f"/api/sources/{source_id}")
 
-    def reindex_source(self, source_id: str) -> dict:
+    def reindex_source(self, source_id: str, full: bool = False) -> dict:
         """Trigger reindex for a source.
 
         Args:
             source_id: Source ID.
+            full: If true, clear metadata and rebuild every file from scratch.
 
         Returns:
             Reindex result with statistics.
         """
-        return self._request("POST", f"/api/sources/{source_id}/reindex")
+        suffix = "?full=true" if full else ""
+        return self._request("POST", f"/api/sources/{source_id}/reindex{suffix}")
 
     # Search endpoints
     def search(

--- a/cli/onesearch/commands/source.py
+++ b/cli/onesearch/commands/source.py
@@ -196,8 +196,9 @@ def source_delete(ctx: Context, source_id: str, yes: bool):
 
 @source.command("reindex")
 @click.argument("source_id")
+@click.option("--full", is_flag=True, help="Clear indexed metadata and rebuild every file from scratch.")
 @pass_context
-def source_reindex(ctx: Context, source_id: str):
+def source_reindex(ctx: Context, source_id: str, full: bool):
     """Trigger reindex for a source.
 
     \b
@@ -205,14 +206,16 @@ def source_reindex(ctx: Context, source_id: str):
       SOURCE_ID  The source ID to reindex
 
     This will scan the source path and index all matching files.
+    Use --full after managed Meilisearch migrations or to repair index drift.
     """
     api = ctx.get_api()
     out = ctx.get_console()
     try:
         s = api.get_source(source_id)
-        out.print(f"[dim]Reindexing source [cyan]{s['name']}[/cyan]...[/dim]")
+        action = "Full reindexing" if full else "Reindexing"
+        out.print(f"[dim]{action} source [cyan]{s['name']}[/cyan]...[/dim]")
 
-        result = api.reindex_source(source_id)
+        result = api.reindex_source(source_id, full=full)
 
         # Backend returns: {"message": ..., "stats": {...}}
         stats = result.get("stats", {})

--- a/cli/tests/test_reindex_full.py
+++ b/cli/tests/test_reindex_full.py
@@ -1,0 +1,42 @@
+from click.testing import CliRunner
+
+from onesearch.context import Context
+from onesearch.main import cli
+
+
+def test_api_reindex_source_can_request_full_rebuild():
+    from onesearch.api import OneSearchAPI
+
+    calls = []
+    api = OneSearchAPI(base_url="http://localhost:8000", token="secret")
+
+    def fake_request(method, endpoint, **kwargs):
+        calls.append((method, endpoint, kwargs))
+        return {"stats": {}}
+
+    api._request = fake_request
+
+    api.reindex_source("docs", full=True)
+
+    assert calls == [("POST", "/api/sources/docs/reindex?full=true", {})]
+
+
+def test_source_reindex_full_flag_calls_full_reindex(monkeypatch):
+    calls = []
+
+    class FakeAPI:
+        def get_source(self, source_id):
+            return {"id": source_id, "name": "Docs", "root_path": "/data/docs"}
+
+        def reindex_source(self, source_id, full=False):
+            calls.append((source_id, full))
+            return {"stats": {"total_scanned": 1, "successful": 1}}
+
+    monkeypatch.setattr(Context, "get_api", lambda self: FakeAPI())
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["source", "reindex", "docs", "--full"], obj=Context())
+
+    assert result.exit_code == 0
+    assert calls == [("docs", True)]
+    assert "Full reindexing source" in result.output

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -196,6 +196,13 @@ curl -X POST http://localhost:8000/api/sources/documents/reindex \
   -H "Authorization: Bearer $TOKEN"
 ```
 
+Use `full=true` to clear indexed metadata and rebuild every file from scratch, such as after a managed Meilisearch migration:
+
+```bash
+curl -X POST "http://localhost:8000/api/sources/documents/reindex?full=true" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
 ### Get Status
 
 ```bash

--- a/docs/getting-started/migrate-to-managed-meilisearch.md
+++ b/docs/getting-started/migrate-to-managed-meilisearch.md
@@ -125,9 +125,26 @@ curl http://localhost:8000/api/health
 
 The health response should show Meilisearch as available.
 
-## 7. Reindex sources
+## 7. Full reindex sources
 
-After switching modes, reindex your sources from the admin UI. The source configuration is kept in OneSearch's database, but the managed Meilisearch index starts with its own `/app/meili_data` volume.
+After switching modes, run a full reindex for each source. Source configuration and indexed-file metadata are kept in OneSearch's SQLite database, but the managed Meilisearch index starts with its own `/app/meili_data` volume. A normal incremental reindex may skip unchanged files because SQLite still remembers them from the old index.
+
+From the admin UI, go to **Admin → Sources** and use the **Full reindex** action for each source. Confirm the source path still exists inside the container before starting.
+
+From the CLI, list sources and run full reindex per source:
+
+```bash
+onesearch source list
+onesearch source reindex <source-id> --full
+```
+
+Or call the API directly:
+
+```bash
+curl -X POST \
+  "http://localhost:8000/api/sources/<source-id>/reindex?full=true" \
+  -H "Authorization: Bearer <token>"
+```
 
 Large source trees may take a while to rebuild. Your original files are not modified.
 

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -77,7 +77,7 @@ The main page has a search box (press `Cmd/Ctrl + K` to focus it), filters for s
 
 ### Admin Section
 
-**Sources**: Manage sources - add, edit, delete, and trigger reindexing.
+**Sources**: Manage sources - add, edit, delete, trigger incremental reindexing, or run a full reindex when rebuilding the search index.
 
 **Status**: Monitor indexing progress, view per-source statistics, and check failed files.
 

--- a/frontend/src/pages/admin/SourcesPage.tsx
+++ b/frontend/src/pages/admin/SourcesPage.tsx
@@ -251,6 +251,7 @@ export default function SourcesPage() {
   const [isAddDialogOpen, setIsAddDialogOpen] = useState(false)
   const [editingSource, setEditingSource] = useState<Source | null>(null)
   const [deletingSource, setDeletingSource] = useState<Source | null>(null)
+  const [fullReindexSource, setFullReindexSource] = useState<Source | null>(null)
   const [reindexingId, setReindexingId] = useState<string | null>(null)
 
   // Queries and mutations
@@ -294,6 +295,17 @@ export default function SourcesPage() {
     reindexMutation.mutate({ id }, {
       onSettled: () => {
         setReindexingId(null)
+      },
+    })
+  }
+
+  const handleFullReindex = () => {
+    if (!fullReindexSource) return
+    setReindexingId(fullReindexSource.id)
+    reindexMutation.mutate({ id: fullReindexSource.id, full: true }, {
+      onSettled: () => {
+        setReindexingId(null)
+        setFullReindexSource(null)
       },
     })
   }
@@ -429,6 +441,15 @@ export default function SourcesPage() {
                         <RefreshCw className={cn("h-4 w-4 transition-transform", reindexingId === source.id && "animate-spin")} />
                       </button>
                       <button
+                        className="min-h-[44px] min-w-[44px] flex items-center justify-center text-muted-foreground hover:text-brand hover:bg-brand/10 rounded-lg transition-all active:scale-95 disabled:opacity-50 disabled:active:scale-100"
+                        title="Full reindex"
+                        aria-label={`Full reindex ${source.name}`}
+                        onClick={() => setFullReindexSource(source)}
+                        disabled={reindexingId === source.id}
+                      >
+                        <Database className="h-4 w-4" />
+                      </button>
+                      <button
                         className="min-h-[44px] min-w-[44px] flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-secondary rounded-lg transition-all active:scale-95"
                         title="Edit"
                         aria-label={`Edit ${source.name}`}
@@ -516,6 +537,35 @@ export default function SourcesPage() {
               error={updateMutation.error}
             />
           )}
+        </DialogContent>
+      </Dialog>
+
+      {/* Full Reindex Confirmation Dialog */}
+      <Dialog open={!!fullReindexSource} onOpenChange={(open) => !open && setFullReindexSource(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Full reindex source?</DialogTitle>
+            <DialogDescription>
+              This clears indexed metadata for {fullReindexSource?.name} and rebuilds every matching file from scratch.
+              Use this after migrating to managed Meilisearch or when search index data is out of sync.
+            </DialogDescription>
+          </DialogHeader>
+          {fullReindexSource && (
+            <Alert>
+              <AlertDescription>
+                Confirm the path exists inside the container first: <code className="font-mono">{fullReindexSource.root_path}</code>
+              </AlertDescription>
+            </Alert>
+          )}
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setFullReindexSource(null)} disabled={reindexMutation.isPending}>
+              Cancel
+            </Button>
+            <Button onClick={handleFullReindex} disabled={reindexMutation.isPending}>
+              {reindexMutation.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              Full reindex
+            </Button>
+          </DialogFooter>
         </DialogContent>
       </Dialog>
 


### PR DESCRIPTION
Adds a proper full reindex path for managed Meilisearch migrations and index repair.

What changed:
- CLI supports `onesearch source reindex <id> --full`
- Admin Sources has a Full reindex action with confirmation
- Backend validates source path before clearing existing index metadata
- Migration/API/user docs updated for full reindex after managed Meili cutover

Checked with:
- pytest backend/tests/test_indexer.py cli/tests -q
- npm run lint
- npm run build