### PR TITLE
Remove Codecov upload

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -65,7 +65,7 @@ jobs:
           MEILI_URL: http://127.0.0.1:7700
           MEILI_MASTER_KEY: test-master-key
         run: |
-          uv run pytest backend/tests/ -v --tb=short --color=yes --cov=app --cov-report=xml
+          uv run pytest backend/tests/ -v --tb=short --color=yes --cov=app
 
       - name: Run CLI tests
         run: |
@@ -81,9 +81,3 @@ jobs:
           name: onesearch-cli-dist
           path: cli/dist/*
 
-      - name: Upload coverage to Codecov
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: codecov/codecov-action@v5
-        with:
-          files: coverage.xml
-          fail_ci_if_error: false


### PR DESCRIPTION
We don't really use Codecov, so this drops the upload step from backend CI.\n\nStill keeps pytest-cov in the backend test command so CI output has coverage locally, but no longer generates coverage.xml just to send it nowhere.