### PR TITLE
Harden path validation and error responses

### DIFF
--- a/backend/app/api/sources.py
+++ b/backend/app/api/sources.py
@@ -33,24 +33,25 @@ router = APIRouter(prefix="/api/sources", tags=["sources"])
 
 def validate_root_path(root_path: Path) -> Path:
     """Validate that root_path exists, is a directory, and is within allowed paths."""
-    if not root_path.exists():
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Root path does not exist: {root_path}"
-        )
-    if not root_path.is_dir():
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Root path is not a directory: {root_path}"
-        )
-
-    resolved = root_path.resolve()
-    allowed = [Path(p.strip()).resolve() for p in settings.allowed_source_paths.split(",") if p.strip()]
+    resolved = root_path.expanduser().resolve(strict=False)
+    allowed = [Path(p.strip()).expanduser().resolve(strict=False) for p in settings.allowed_source_paths.split(",") if p.strip()]
     if allowed and not any(resolved == a or a in resolved.parents for a in allowed):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Root path is outside allowed directories ({settings.allowed_source_paths})"
+            detail="Root path is outside allowed directories"
         )
+
+    if not resolved.exists():
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Root path does not exist"
+        )
+    if not resolved.is_dir():
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Root path is not a directory"
+        )
+
     return resolved
 
 

--- a/backend/app/api/status.py
+++ b/backend/app/api/status.py
@@ -52,13 +52,13 @@ async def get_status(db: Session = Depends(get_db), current_user: User = Depends
         try:
             source_status = indexing_service.get_source_status(source.id)
             status_list.append(source_status)
-        except Exception as e:
-            logger.error(f"Failed to get status for source {source.id}: {e}")
-            # Return partial status even if one fails
+        except Exception:
+            logger.exception("Failed to get status for source %s", source.id)
+            # Return partial status even if one fails, without exposing internals.
             status_list.append({
                 "source_id": source.id,
                 "source_name": source.name,
-                "error": str(e),
+                "error": "Status unavailable",
             })
 
     return {"sources": status_list}

--- a/backend/app/services/search.py
+++ b/backend/app/services/search.py
@@ -131,8 +131,9 @@ class MeilisearchService:
                 "is_indexing": is_indexing,
             }
 
-        except Exception as e:
-            return {"status": "error", "error": str(e)}
+        except Exception:
+            logger.exception("Meilisearch health check failed")
+            return {"status": "error", "error": "Meilisearch health check failed"}
 
     async def index_documents(self, documents: List[Any]) -> Dict[str, Any]:
         """

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -267,6 +267,25 @@ class TestSourceEndpoints:
         assert response.status_code == 400
         assert "does not exist" in response.json()["detail"].lower()
 
+    def test_create_source_checks_allowed_paths_before_stat(self, client, tmp_path, monkeypatch):
+        """Outside allowed roots should not disclose whether the path exists or is a file."""
+        allowed_dir = tmp_path / "allowed"
+        allowed_dir.mkdir()
+        outside_file = tmp_path / "outside-secret.txt"
+        outside_file.write_text("secret")
+        monkeypatch.setattr("app.api.sources.settings.allowed_source_paths", str(allowed_dir))
+
+        response = client.post("/api/sources", json={
+            "name": "Outside Source",
+            "root_path": str(outside_file),
+        })
+
+        assert response.status_code == 400
+        detail = response.json()["detail"].lower()
+        assert "outside allowed" in detail
+        assert "not a directory" not in detail
+        assert "does not exist" not in detail
+
     def test_create_source_path_is_file(self, client, temp_source_dir):
         """Test creating source with file path (not directory) fails"""
         file_path = str(Path(temp_source_dir) / "test1.txt")
@@ -730,6 +749,23 @@ class TestStatusEndpoint:
         assert "sources" in data
         assert len(data["sources"]) == 1
         assert data["sources"][0]["source_id"] == sample_source.id
+
+    def test_get_all_status_does_not_expose_internal_exception(self, client, sample_source, monkeypatch):
+        """Partial status fallback should not return raw exception details."""
+        class FailingIndexingService:
+            def __init__(self, db, search_service):
+                pass
+
+            def get_source_status(self, source_id):
+                raise RuntimeError("traceback leaked /srv/private/token.txt")
+
+        monkeypatch.setattr("app.api.status.IndexingService", FailingIndexingService)
+
+        response = client.get("/api/status")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["sources"][0]["error"] == "Status unavailable"
 
     def test_get_source_status_success(self, client, sample_source):
         """Test getting status for specific source"""

--- a/backend/tests/test_search_service.py
+++ b/backend/tests/test_search_service.py
@@ -94,12 +94,12 @@ class TestHealthCheck:
         assert "error" in result
 
     def test_health_check_error(self, connected_service):
-        connected_service.client.health.side_effect = Exception("timeout")
+        connected_service.client.health.side_effect = Exception("timeout /srv/private/token.txt")
 
         result = connected_service.health_check()
 
         assert result["status"] == "error"
-        assert "timeout" in result["error"]
+        assert result["error"] == "Meilisearch health check failed"
 
     def test_health_check_dict_response(self, connected_service):
         """Handle Meilisearch returning dicts instead of objects"""


### PR DESCRIPTION
Tightens a couple of CodeQL findings instead of dismissing them.

Source path validation now checks the resolved path against allowed roots before doing existence/type checks, so paths outside the allowlist don't disclose whether something exists or is a file. Status and health fallbacks now return generic client-facing errors while logging the full exception server-side.

Verified with backend tests: 309 passed, 6 skipped.
