### PR TITLE
Make managed Meilisearch the default deployment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,19 +1,16 @@
 # Meilisearch Configuration
+# Managed Meilisearch is the default Docker deployment.
 # Generate a secure random key: openssl rand -base64 32
 MEILI_MASTER_KEY=your-secure-master-key-here
+
+# Set ONESEARCH_MANAGED_MEILI=false and MEILI_URL only if you use
+# docker-compose.legacy.yml or another external Meilisearch instance.
+ONESEARCH_MANAGED_MEILI=true
+# MEILI_URL=http://meilisearch:7700
 
 # Database Configuration
 # SQLite database will be stored at /app/data/onesearch.db inside the container
 DATABASE_URL=sqlite:////app/data/onesearch.db
-
-# Meilisearch URL (internal Docker network)
-# Leave this as-is for the default external Meilisearch compose setup.
-MEILI_URL=http://meilisearch:7700
-
-# Experimental/opt-in: run Meilisearch inside the OneSearch container instead
-# of using the separate meilisearch service. Use docker-compose.managed-meili.yml
-# for this; existing two-container installs should leave it disabled.
-# ONESEARCH_MANAGED_MEILI=false
 
 # Logging
 LOG_LEVEL=INFO

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to OneSearch will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Added `docker-compose.legacy.yml` for existing and advanced installs that want to keep Meilisearch as a separate service.
+
+### Changed
+
+- Managed Meilisearch is now the default Docker deployment. New installs use a single OneSearch container with the search engine managed internally.
+- The default `docker-compose.yml` now stores the bundled Meilisearch index in `onesearch_index:/app/meili_data`.
+- The legacy external Meilisearch compose setup remains supported, but is no longer the recommended new-install path.
+- Installation, upgrade, and migration docs now distinguish new managed installs from existing two-container installs.
+
 ## [0.15.1] - 2026-06-03
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ docker-compose up -d
 
 Open http://localhost:8000, run through the setup wizard, add a directory as a source, and start searching.
 
-> **Heads up:** OneSearch is moving toward an easier single-container setup. The default install still runs Meilisearch as a separate container, but v0.13 adds an opt-in managed Meilisearch mode where OneSearch starts Meilisearch inside the app container. If you want to try it, use `docker-compose.managed-meili.yml`; existing installs should read the [migration guide](https://onesearch.readthedocs.io/en/latest/getting-started/migrate-to-managed-meilisearch/) first. Existing installs do not need to change.
+> **Existing installs:** the default Docker setup now runs OneSearch and managed Meilisearch in a single container. Existing two-container installs do not need to switch immediately. If you do switch, keep your `/app/data` volume and run a full reindex after moving to managed mode. The old two-container external Meilisearch setup is still supported in `docker-compose.legacy.yml`.
 
 Full setup guide: [onesearch.readthedocs.io](https://onesearch.readthedocs.io/en/latest/getting-started/installation/)
 

--- a/backend/tests/test_compose_defaults.py
+++ b/backend/tests/test_compose_defaults.py
@@ -1,0 +1,31 @@
+# Copyright (C) 2026 demigodmode
+# SPDX-License-Identifier: AGPL-3.0-only
+
+from pathlib import Path
+
+
+def test_default_compose_uses_managed_meili():
+    text = Path("docker-compose.yml").read_text()
+
+    assert "  meilisearch:" not in text
+    assert "ONESEARCH_MANAGED_MEILI=true" in text
+    assert "MEILI_URL=http://meilisearch:7700" not in text
+    assert "onesearch_index:/app/meili_data" in text
+
+
+def test_legacy_compose_keeps_two_container_mode():
+    text = Path("docker-compose.legacy.yml").read_text()
+
+    assert "  meilisearch:" in text
+    assert "getmeili/meilisearch:v1.12" in text
+    assert "MEILI_URL=http://meilisearch:7700" in text
+    assert "ONESEARCH_MANAGED_MEILI=true" not in text
+
+
+def test_managed_alias_matches_default_mode():
+    text = Path("docker-compose.managed-meili.yml").read_text()
+
+    assert "Compatibility copy" in text
+    assert "ONESEARCH_MANAGED_MEILI=true" in text
+    assert "MEILI_URL=http://meilisearch:7700" not in text
+    assert "onesearch_index:/app/meili_data" in text

--- a/docker-compose.legacy.yml
+++ b/docker-compose.legacy.yml
@@ -1,5 +1,24 @@
 services:
-  # OneSearch - Unified application with managed Meilisearch
+  # Meilisearch - Fast search engine
+  meilisearch:
+    image: getmeili/meilisearch:v1.12
+    container_name: onesearch-meilisearch
+    volumes:
+      - meilisearch_data:/meili_data
+    environment:
+      - MEILI_MASTER_KEY=${MEILI_MASTER_KEY}
+      - MEILI_ENV=production
+    networks:
+      - onesearch_network
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--spider", "http://127.0.0.1:7700/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
+
+  # OneSearch - Unified application (frontend + backend + CLI)
   onesearch:
     # For local development, build from source:
     build:
@@ -14,9 +33,6 @@ services:
       # Persistent data (SQLite database)
       - onesearch_data:/app/data
 
-      # Persistent managed Meilisearch index data
-      - onesearch_index:/app/meili_data
-
       # Example source mounts (uncomment and modify as needed)
       # Add your local directories or NAS mounts here
       # Format: /host/path:/container/path:ro (ro = read-only)
@@ -26,13 +42,18 @@ services:
       # - /path/to/photos:/data/photos:ro
 
     environment:
-      - ONESEARCH_MANAGED_MEILI=true
+      - MEILI_URL=http://meilisearch:7700
       - MEILI_MASTER_KEY=${MEILI_MASTER_KEY}
       - SESSION_SECRET=${SESSION_SECRET}
       - DATABASE_URL=sqlite:////app/data/onesearch.db
       - LOG_LEVEL=${LOG_LEVEL:-INFO}
     ports:
       - "8000:8000"
+    depends_on:
+      meilisearch:
+        condition: service_healthy
+    networks:
+      - onesearch_network
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "curl", "-f", "http://127.0.0.1:8000/api/health"]
@@ -42,10 +63,14 @@ services:
       start_period: 30s
 
 volumes:
+  # Meilisearch index data
+  meilisearch_data:
+    driver: local
+
   # OneSearch database and application data
   onesearch_data:
     driver: local
 
-  # Managed Meilisearch index data
-  onesearch_index:
-    driver: local
+networks:
+  onesearch_network:
+    driver: bridge

--- a/docker-compose.managed-meili.yml
+++ b/docker-compose.managed-meili.yml
@@ -1,25 +1,31 @@
 services:
-  # OneSearch with managed Meilisearch inside the app container.
-  # Experimental/opt-in while bundled search backend support is validated.
+  # Compatibility copy of the managed Meilisearch compose file.
+  # Managed mode is now the default in docker-compose.yml; this file is kept
+  # for users who already followed the v0.13-v0.15 managed-mode docs.
+  # New installs should use docker-compose.yml.
   onesearch:
     build:
       context: .
       dockerfile: Dockerfile
 
-    # For a released image, replace build with:
+    # For production, use the pre-built image instead:
     # image: ghcr.io/demigodmode/onesearch:latest
 
     container_name: onesearch-app
     volumes:
-      # Persistent SQLite database
+      # Persistent data (SQLite database)
       - onesearch_data:/app/data
 
       # Persistent managed Meilisearch index data
       - onesearch_index:/app/meili_data
 
       # Example source mounts (uncomment and modify as needed)
+      # Add your local directories or NAS mounts here
+      # Format: /host/path:/container/path:ro (ro = read-only)
+
       # - /mnt/nas/documents:/data/nas_docs:ro
       # - /home/user/Documents:/data/documents:ro
+      # - /path/to/photos:/data/photos:ro
 
     environment:
       - ONESEARCH_MANAGED_MEILI=true
@@ -38,7 +44,10 @@ services:
       start_period: 30s
 
 volumes:
+  # OneSearch database and application data
   onesearch_data:
     driver: local
+
+  # Managed Meilisearch index data
   onesearch_index:
     driver: local

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -1,30 +1,8 @@
 # Changelog
 
-All notable changes to OneSearch are documented here.
+All notable changes to OneSearch are documented in the project changelog.
 
-The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
----
-
-## Latest Release
-
-**v0.10.0** - 2026-03-18
-
-After cycling through cyan, indigo, and amber across three versions, decided to just let you pick. Five accent color presets (Amber, Indigo, Cyan, Teal, Rose) plus a custom hue slider in Admin -> Settings. Choice persists to localStorage with no flash on reload.
-
-**v0.9.1** - 2026-03-14
-
-Brand color switched to amber with warm-tinted backgrounds.
-
-**v0.9.0** - 2026-03-14
-
-Full UI redesign: removed hero section, replaced metric cards with compact status bar, container queries for responsive tables, lazy-loaded document preview with PrismLight, accessibility pass, and a release script for version management.
-
----
-
-## Full Changelog
-
-For the complete version history with detailed changelogs, see:
+For the complete version history with detailed release notes, see:
 
 **[CHANGELOG.md on GitHub](https://github.com/demigodmode/OneSearch/blob/main/CHANGELOG.md)**
 

--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -8,7 +8,7 @@ OneSearch is configured through environment variables, typically set in a `.env`
 
 **Required**
 
-The master key for your Meilisearch instance. This protects the search API.
+The master key for the managed or external Meilisearch instance. This protects the search API.
 
 Generate a secure key:
 
@@ -44,14 +44,23 @@ The database stores source configurations and file metadata for incremental inde
 
 ### Meilisearch
 
+**ONESEARCH_MANAGED_MEILI**
+
+Whether OneSearch starts the bundled Meilisearch process inside the app container.
+
+- Default Docker quickstart: `true`
+- Options: `true`, `false`
+
+For the default Docker install, leave `ONESEARCH_MANAGED_MEILI=true` and do not set `MEILI_URL`. OneSearch starts Meilisearch on `127.0.0.1:7700` and points the backend at it internally.
+
 **MEILI_URL**
 
-Meilisearch endpoint.
+Meilisearch endpoint for external Meilisearch mode.
 
-- Default: `http://meilisearch:7700`
-- Example: `http://meilisearch:7700`
+- Required only when `ONESEARCH_MANAGED_MEILI=false`
+- Legacy compose example: `http://meilisearch:7700`
 
-In Docker Compose, use the container name (`meilisearch`). If running Meilisearch separately, use the full URL.
+If you use `docker-compose.legacy.yml`, set `MEILI_URL=http://meilisearch:7700` or point it at your own Meilisearch instance. External-mode users manage Meilisearch version compatibility themselves.
 
 ### Logging
 
@@ -279,7 +288,8 @@ MEILI_MASTER_KEY=YourSecureRandomKeyHere123456789
 
 # Optional - these show the defaults
 DATABASE_URL=sqlite:////app/data/onesearch.db
-MEILI_URL=http://meilisearch:7700
+ONESEARCH_MANAGED_MEILI=true
+# MEILI_URL=http://meilisearch:7700  # Only for docker-compose.legacy.yml or another external Meilisearch instance
 LOG_LEVEL=INFO
 
 # File size limits (in MB)
@@ -396,7 +406,7 @@ If you have powerful hardware:
 
 ### Meilisearch connection failed
 
-Check that `MEILI_MASTER_KEY` matches in both the OneSearch and Meilisearch containers. Both need the same key.
+For the default managed install, check that `ONESEARCH_MANAGED_MEILI=true` and `MEILI_MASTER_KEY` is set. For `docker-compose.legacy.yml` or another external Meilisearch instance, check that `MEILI_URL` points to the external service and that both containers use the same `MEILI_MASTER_KEY`.
 
 ### Files being skipped
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -34,9 +34,9 @@ curl -O https://raw.githubusercontent.com/demigodmode/OneSearch/main/.env.exampl
 cp .env.example .env
 ```
 
-### Generate a Meilisearch master key
+### Generate a search master key
 
-You need a secure random key to protect your Meilisearch instance:
+You need a secure random key to protect the managed Meilisearch search API:
 
 **Linux/macOS:**
 ```bash
@@ -107,7 +107,7 @@ Check that services started:
 docker-compose ps
 ```
 
-You should see `onesearch` and `meilisearch` running.
+You should see `onesearch` running. The managed Meilisearch process runs inside that container.
 
 Check logs if something looks wrong:
 
@@ -119,25 +119,23 @@ docker-compose logs -f onesearch
 
 Open http://localhost:8000 in your browser. You should see the OneSearch search page.
 
-### Optional: managed Meilisearch mode
+### Advanced: legacy external Meilisearch mode
 
-The default compose file runs Meilisearch as a separate container. That is still the recommended path for most installs.
+The default compose file runs managed Meilisearch inside the OneSearch container. External Meilisearch is still supported for existing installs, Kubernetes-style deployments, or users who want to manage the search engine separately.
 
-There is also an opt-in managed mode where OneSearch starts Meilisearch inside the app container. It's useful if you want a single app container and don't want to manage a separate Meilisearch service. Existing installs do not need to switch.
-
-To try it, download the managed compose file instead:
+To use the old two-container setup, download the legacy compose file:
 
 ```bash
-curl -O https://raw.githubusercontent.com/demigodmode/OneSearch/main/docker-compose.managed-meili.yml
+curl -O https://raw.githubusercontent.com/demigodmode/OneSearch/main/docker-compose.legacy.yml
 ```
 
 Then start with:
 
 ```bash
-docker-compose -f docker-compose.managed-meili.yml up -d
+docker-compose -f docker-compose.legacy.yml up -d
 ```
 
-Managed mode still needs `MEILI_MASTER_KEY` in `.env`. It stores the SQLite database in `/app/data` and the bundled Meilisearch index in `/app/meili_data`, so keep both volumes if you want data to survive restarts. If you're switching an existing install, read [Migrating to managed Meilisearch](migrate-to-managed-meilisearch.md) first.
+External-mode users manage the Meilisearch version and index compatibility themselves. If you're switching an existing two-container install to the default managed setup, read [Migrating to managed Meilisearch](migrate-to-managed-meilisearch.md) first and plan to run a full reindex.
 
 ---
 

--- a/docs/getting-started/migrate-to-managed-meilisearch.md
+++ b/docs/getting-started/migrate-to-managed-meilisearch.md
@@ -1,8 +1,8 @@
 # Migrating to managed Meilisearch
 
-Managed Meilisearch runs the search engine inside the OneSearch app container. The regular two-container setup still works, so there is no rush to switch existing installs.
+Managed Meilisearch runs the search engine inside the OneSearch app container and is the default for new OneSearch installs. The older two-container setup still works, so there is no rush to switch existing installs.
 
-Use this guide if you want to try the managed mode introduced in v0.13.
+Use this guide if you already run the older two-container setup and want to migrate to the single-container managed setup. If your existing install is working and you want to keep Meilisearch separate, use `docker-compose.legacy.yml`.
 
 ## Before you start
 
@@ -24,7 +24,7 @@ docker-compose down
 Back up the compose/env files:
 
 ```bash
-cp docker-compose.yml docker-compose.external-meili.backup.yml
+cp docker-compose.yml docker-compose.legacy.backup.yml
 cp .env .env.backup
 ```
 
@@ -48,13 +48,13 @@ docker run --rm \
 
 You can also back up the old Meilisearch volume if you want to keep it around, but managed mode does not reuse the external container's `/meili_data` volume directly.
 
-## 2. Download the managed compose file
+## 2. Download the current compose file
 
 ```bash
-curl -O https://raw.githubusercontent.com/demigodmode/OneSearch/main/docker-compose.managed-meili.yml
+curl -O https://raw.githubusercontent.com/demigodmode/OneSearch/main/docker-compose.yml
 ```
 
-If you are running from a git checkout, the file is already in the repo.
+If you are running from a git checkout, the file is already in the repo. In v1.0 and later, `docker-compose.yml` is the managed Meilisearch setup.
 
 ## 3. Check `.env`
 
@@ -78,7 +78,7 @@ volumes:
   - /mnt/nas/documents:/data/documents:ro
 ```
 
-copy the source mounts into the `onesearch` service in `docker-compose.managed-meili.yml`:
+copy the source mounts into the `onesearch` service in the new `docker-compose.yml`:
 
 ```yaml
 volumes:
@@ -92,19 +92,19 @@ Keep source mounts read-only unless you have a specific reason not to.
 ## 5. Start managed mode
 
 ```bash
-docker-compose -f docker-compose.managed-meili.yml up -d
+docker-compose up -d
 ```
 
 Check the container status:
 
 ```bash
-docker-compose -f docker-compose.managed-meili.yml ps
+docker-compose ps
 ```
 
 Follow logs during the first start:
 
 ```bash
-docker-compose -f docker-compose.managed-meili.yml logs -f onesearch
+docker-compose logs -f onesearch
 ```
 
 You should see OneSearch start, then managed Meilisearch become ready.
@@ -153,13 +153,13 @@ Large source trees may take a while to rebuild. Your original files are not modi
 If managed mode does not work for your setup:
 
 ```bash
-docker-compose -f docker-compose.managed-meili.yml down
+docker-compose down
 ```
 
 Start the previous two-container setup again:
 
 ```bash
-docker-compose -f docker-compose.external-meili.backup.yml up -d
+docker-compose -f docker-compose.legacy.backup.yml up -d
 ```
 
 If you did not change your old Meilisearch volume, the external setup should come back with the old index data.

--- a/docs/getting-started/upgrading.md
+++ b/docs/getting-started/upgrading.md
@@ -49,25 +49,25 @@ docker run -d \
   --name watchtower \
   -v /var/run/docker.sock:/var/run/docker.sock \
   containrrr/watchtower \
-  onesearch-app onesearch-meilisearch \
+  onesearch-app \
   --schedule "0 0 4 * * *"  # Daily at 4 AM
 ```
 
 You can pin to specific tags if you want more control:
 - `latest` - Always get the newest release
-- `0.7` - Stay on the 0.7.x line (minor/patch updates only)
-- `0.7.2` - Pin to a specific version (no auto-updates)
+- `1` - Stay on the 1.x line
+- `1.0` - Stay on the 1.0.x line
+- `1.0.0` - Pin to a specific version (no auto-updates)
 
 ---
 
-## Managed Meilisearch mode
+## v1.0.0: managed Meilisearch is the default setup
 
-Managed Meilisearch is opt-in. Upgrading does not change existing two-container installs; if your compose file has a separate `meilisearch` service, it will keep working that way.
+New installs use a single OneSearch container with managed Meilisearch. Existing two-container installs keep working; do not overwrite your existing compose file unless you intend to migrate.
 
-If you switch to `docker-compose.managed-meili.yml`, OneSearch runs Meilisearch inside the app container and points the backend at `http://127.0.0.1:7700`. Keep these volumes around:
+If you want to migrate, back up your compose/env files, keep the OneSearch data volume mounted at `/app/data`, add the managed index volume at `/app/meili_data`, and run a full reindex for each source after startup.
 
-- `/app/data` for the SQLite database
-- `/app/meili_data` for the bundled Meilisearch index
+If you want to stay on the two-container setup, use `docker-compose.legacy.yml`. That mode is still supported for existing installs and advanced deployments, but you manage Meilisearch version compatibility yourself.
 
 The search index is derived from your configured sources, so it can be rebuilt if needed. The source files and OneSearch database are the important data to preserve. For the step-by-step flow, see [Migrating to managed Meilisearch](migrate-to-managed-meilisearch.md).
 


### PR DESCRIPTION
Managed Meilisearch is now the default Docker setup. New installs get one OneSearch container with the bundled search engine; the old two-container setup is preserved as docker-compose.legacy.yml for existing and advanced installs.

Docs now call out the migration path and full reindex requirement if someone switches an existing install.

Verified backend/frontend/docs plus managed smoke on pi5.
