### PR TITLE
Fix live indexing and Docker runtime permissions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,11 @@ LOG_LEVEL=INFO
 # CORS_ORIGINS=                   # Comma-separated origins; empty uses localhost defaults
 # ALLOWED_SOURCE_PATHS=/data       # Comma-separated container paths allowed as source roots
 
+# Optional: runtime user/group for mounted volumes
+# Set these to a host user/group that can read your source mounts and write app volumes.
+# PUID=1000
+# PGID=1000
+
 # Optional: Max file sizes (in MB)
 # MAX_TEXT_FILE_SIZE_MB=10
 # MAX_PDF_FILE_SIZE_MB=50

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to OneSearch will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Added Docker `PUID` and `PGID` support so the runtime user can match host users or shared groups for mounted volumes.
+
+### Fixed
+
+- Fixed live-source indexing crashes when a file disappears after scanning but before extraction.
+- Fixed Meilisearch indexing failures caused by datetime values in nested document metadata.
+- Improved malformed Markdown frontmatter handling so the markdown body is still indexed as plain content.
+
+---
+
 ## [1.0.1] - 2026-06-04
 
 ### Security

--- a/backend/app/container/supervisord.py
+++ b/backend/app/container/supervisord.py
@@ -47,6 +47,7 @@ MEILISEARCH_COMMAND = " ".join([
 
 MEILISEARCH_PROGRAM = f"""[program:meilisearch]
 command={MEILISEARCH_COMMAND}
+directory=/app/meili_data
 user=onesearch
 autostart=true
 autorestart=true

--- a/backend/app/extractors/markdown.py
+++ b/backend/app/extractors/markdown.py
@@ -8,6 +8,7 @@ Extracts content and metadata from markdown documents
 import logging
 import frontmatter
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Dict, Any
 
 from .base import BaseExtractor, extractor_registry
@@ -92,18 +93,37 @@ class MarkdownExtractor(BaseExtractor):
         except Exception as e:
             # Graceful fallback for unexpected errors (e.g., invalid YAML front-matter)
             logger.warning(
-                f"Unexpected error extracting markdown from {file_path}: {e}. File will be indexed by filename only.",
+                f"Unexpected error extracting markdown from {file_path}: {e}. File will be indexed as plain markdown.",
                 extra={"file_path": file_path, "error": str(e)},
                 exc_info=True
             )
-            # Create minimal document
-            doc = self._create_base_document(file_path, "")
-            doc.title = Path(file_path).stem
+            content = self._read_markdown_text(file_path)
+            content = self._strip_frontmatter_block(content)
+            doc = self._create_base_document(file_path, content)
+            fallback_post = SimpleNamespace(metadata={})
+            doc.title = self._extract_title(fallback_post, content, file_path)
             doc.metadata = {
-                "extraction_error": str(e),
-                "extraction_failed": True,
+                "has_frontmatter": False,
+                "frontmatter_error": str(e),
+                "extraction_failed": False,
             }
             return doc
+
+    def _read_markdown_text(self, file_path: str) -> str:
+        try:
+            return Path(file_path).read_text(encoding='utf-8')
+        except UnicodeDecodeError:
+            return Path(file_path).read_text(encoding='latin-1')
+
+    def _strip_frontmatter_block(self, text: str) -> str:
+        lines = text.splitlines()
+        if not lines or lines[0].strip() != '---':
+            return text
+
+        for index, line in enumerate(lines[1:], start=1):
+            if line.strip() == '---':
+                return "\n".join(lines[index + 1:]).lstrip("\n")
+        return text
 
     def _parse_markdown(self, file_path: str) -> tuple[Any, str, Dict[str, Any]]:
         """

--- a/backend/app/services/indexer.py
+++ b/backend/app/services/indexer.py
@@ -160,7 +160,7 @@ class IndexingService:
             documents_to_index = []
             files_processed = 0
 
-            for file_path in current_files:
+            for file_path in list(current_files):
                 files_processed += 1
                 try:
                     # Check if file needs indexing

--- a/backend/app/services/search.py
+++ b/backend/app/services/search.py
@@ -153,7 +153,7 @@ class MeilisearchService:
             doc_dicts = []
             for doc in documents:
                 if hasattr(doc, 'model_dump'):  # Pydantic model
-                    doc_dicts.append(doc.model_dump())
+                    doc_dicts.append(doc.model_dump(mode="json"))
                 elif isinstance(doc, dict):
                     doc_dicts.append(doc)
                 else:

--- a/backend/tests/test_compose_defaults.py
+++ b/backend/tests/test_compose_defaults.py
@@ -29,3 +29,15 @@ def test_managed_alias_matches_default_mode():
     assert "ONESEARCH_MANAGED_MEILI=true" in text
     assert "MEILI_URL=http://meilisearch:7700" not in text
     assert "onesearch_index:/app/meili_data" in text
+
+
+def test_compose_files_expose_runtime_uid_gid_defaults():
+    for compose_file in [
+        "docker-compose.yml",
+        "docker-compose.managed-meili.yml",
+        "docker-compose.legacy.yml",
+    ]:
+        text = Path(compose_file).read_text()
+
+        assert "PUID=${PUID:-1000}" in text
+        assert "PGID=${PGID:-1000}" in text

--- a/backend/tests/test_dockerfile.py
+++ b/backend/tests/test_dockerfile.py
@@ -9,3 +9,13 @@ def test_runtime_image_installs_exiftool_for_raw_metadata():
     dockerfile = Path("Dockerfile").read_text(encoding="utf-8")
 
     assert "libimage-exiftool-perl" in dockerfile
+
+
+def test_entrypoint_supports_runtime_puid_pgid_mapping():
+    entrypoint = Path("entrypoint.sh").read_text(encoding="utf-8")
+
+    assert "PUID" in entrypoint
+    assert "PGID" in entrypoint
+    assert "groupmod" in entrypoint
+    assert "usermod" in entrypoint
+    assert "su -s /bin/bash -p onesearch" in entrypoint

--- a/backend/tests/test_extractors.py
+++ b/backend/tests/test_extractors.py
@@ -258,10 +258,11 @@ class TestMarkdownExtractor:
         extractor = MarkdownExtractor("test_source", "Test Source")
         doc = await extractor.extract_with_timeout(str(file_path))
 
-        # Should still produce a document (graceful fallback)
         assert doc is not None
-        # Either parsed successfully or fell back to filename
-        assert doc.title is not None
+        assert doc.title == "Content"
+        assert "Content" in doc.content
+        assert doc.metadata["has_frontmatter"] is False
+        assert "frontmatter_error" in doc.metadata
 
     @pytest.mark.asyncio
     async def test_empty_markdown_file(self, temp_dir):

--- a/backend/tests/test_indexer.py
+++ b/backend/tests/test_indexer.py
@@ -470,6 +470,54 @@ class TestIndexingService:
 
     @pytest.mark.asyncio
     @patch('app.services.indexer.FileScanner')
+    async def test_index_source_handles_file_deleted_after_scan(
+        self,
+        mock_scanner_class,
+        db_session,
+        mock_search_service,
+        test_directory
+    ):
+        """Files that disappear after scanning should not crash a live-source indexing run."""
+        disappearing_file = test_directory / "gone.txt"
+        disappearing_path = str(disappearing_file)
+        disappearing_file.write_text("temporary content")
+        indexed_file = IndexedFile(
+            source_id="live_source",
+            path=disappearing_path,
+            size_bytes=disappearing_file.stat().st_size,
+            modified_at=datetime.fromtimestamp(disappearing_file.stat().st_mtime),
+            indexed_at=datetime.now(timezone.utc).replace(tzinfo=None),
+            status="success",
+        )
+        source = Source(
+            id="live_source",
+            name="Live Source",
+            root_path=str(test_directory),
+            include_patterns=json.dumps(["**/*.txt"]),
+            exclude_patterns=json.dumps([])
+        )
+        db_session.add_all([source, indexed_file])
+        db_session.commit()
+        disappearing_file.unlink()
+        mock_scanner = Mock()
+        mock_scanner.scan.return_value = [disappearing_path]
+        mock_scanner_class.return_value = mock_scanner
+
+        service = IndexingService(db_session, mock_search_service)
+        stats = await service.index_source("live_source")
+
+        assert stats.total_scanned == 1
+        assert stats.failed == 0
+        assert stats.deleted_files == 1
+        mock_search_service.delete_document.assert_awaited_once()
+        remaining = db_session.query(IndexedFile).filter_by(
+            source_id="live_source",
+            path=disappearing_path,
+        ).first()
+        assert remaining is None
+
+    @pytest.mark.asyncio
+    @patch('app.services.indexer.FileScanner')
     async def test_index_source_indexes_unsupported_file_as_metadata_only(
         self,
         mock_scanner_class,

--- a/backend/tests/test_search_service.py
+++ b/backend/tests/test_search_service.py
@@ -5,10 +5,13 @@
 Tests for MeilisearchService - mocked, no running instance needed
 """
 import json
+from datetime import datetime
+
 import pytest
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
+from app.schemas import Document
 from app.services.search import MeilisearchService, INDEX_NAME
 
 
@@ -128,6 +131,30 @@ class TestIndexDocuments:
 
         assert result["task_uid"] == 1
         connected_service.index.add_documents.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_index_pydantic_models_uses_json_safe_values(self, connected_service):
+        doc = Document(
+            id="doc-date",
+            source_id="src",
+            source_name="Source",
+            path="/tmp/note.md",
+            basename="note.md",
+            extension="md",
+            type="markdown",
+            size_bytes=10,
+            modified_at=1,
+            indexed_at=2,
+            content="note",
+            metadata={"frontmatter": {"published": datetime(2026, 6, 5, 12, 30)}}
+        )
+        task = _fake_task(task_uid=7)
+        connected_service.index.add_documents.return_value = task
+
+        await connected_service.index_documents([doc])
+
+        indexed_docs = connected_service.index.add_documents.call_args.args[0]
+        assert indexed_docs[0]["metadata"]["frontmatter"]["published"] == "2026-06-05T12:30:00"
 
     @pytest.mark.asyncio
     async def test_index_dicts(self, connected_service):

--- a/backend/tests/test_supervisord_config.py
+++ b/backend/tests/test_supervisord_config.py
@@ -15,6 +15,7 @@ def test_managed_meili_config_starts_meilisearch_and_points_api_at_localhost():
     assert "MEILI_URL=\"http://127.0.0.1:7700\"" in config
     assert "MEILI_MASTER_KEY=\"%(ENV_MEILI_MASTER_KEY)s\"" in config
     assert "MEILI_ENV=\"production\"" in config
+    assert "directory=/app/meili_data" in config
     assert "command=/app/start-backend.sh" in config
 
 

--- a/docker-compose.legacy.yml
+++ b/docker-compose.legacy.yml
@@ -45,6 +45,8 @@ services:
       - MEILI_URL=http://meilisearch:7700
       - MEILI_MASTER_KEY=${MEILI_MASTER_KEY}
       - SESSION_SECRET=${SESSION_SECRET}
+      - PUID=${PUID:-1000}
+      - PGID=${PGID:-1000}
       - DATABASE_URL=sqlite:////app/data/onesearch.db
       - LOG_LEVEL=${LOG_LEVEL:-INFO}
     ports:

--- a/docker-compose.managed-meili.yml
+++ b/docker-compose.managed-meili.yml
@@ -31,6 +31,8 @@ services:
       - ONESEARCH_MANAGED_MEILI=true
       - MEILI_MASTER_KEY=${MEILI_MASTER_KEY}
       - SESSION_SECRET=${SESSION_SECRET}
+      - PUID=${PUID:-1000}
+      - PGID=${PGID:-1000}
       - DATABASE_URL=sqlite:////app/data/onesearch.db
       - LOG_LEVEL=${LOG_LEVEL:-INFO}
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,8 @@ services:
       - ONESEARCH_MANAGED_MEILI=true
       - MEILI_MASTER_KEY=${MEILI_MASTER_KEY}
       - SESSION_SECRET=${SESSION_SECRET}
+      - PUID=${PUID:-1000}
+      - PGID=${PGID:-1000}
       - DATABASE_URL=sqlite:////app/data/onesearch.db
       - LOG_LEVEL=${LOG_LEVEL:-INFO}
     ports:

--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -82,6 +82,19 @@ Comma-separated parent directories that sources must live under.
 
 This is a safety guard. If you try to add a source outside these paths, the API rejects it before indexing. In Docker, make sure this matches the container paths you mount, not host paths.
 
+### Runtime User and Mounted Volumes
+
+**PUID** / **PGID**
+
+UID and GID used by the OneSearch backend process inside the container.
+
+- Default: `1000` / `1000`
+- Example: `PUID=1001`, `PGID=100`
+
+Set these when your source directories are readable by a specific host user or shared group, especially on NAS, SMB/NFS, or homelab setups. OneSearch adjusts the internal `onesearch` user at startup, then runs the backend and managed Meilisearch as that identity.
+
+The IDs must be numeric. The container still needs write access to `/app/data` and, in managed mode, `/app/meili_data`.
+
 ### Logging
 
 **LOG_LEVEL**

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -93,6 +93,8 @@ The `:ro` flag mounts volumes as read-only, which is recommended for safety.
 
 Use the container path (like `/data/documents`) when adding sources later, not the host path.
 
+If your mounted files are readable by a specific host user or shared group, set `PUID` and `PGID` in `.env` to those numeric IDs. This is common for NAS, SMB/NFS, and homelab service-group setups.
+
 ### Start OneSearch
 
 ```bash

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,9 +6,48 @@ set -e
 
 echo "Starting OneSearch..."
 
-# Ensure data directories are owned by onesearch user
+configure_runtime_user() {
+    local target_uid="${PUID:-$(id -u onesearch)}"
+    local target_gid="${PGID:-$(id -g onesearch)}"
+
+    if [[ ! "$target_uid" =~ ^[0-9]+$ ]]; then
+        echo "PUID must be a numeric user ID" >&2
+        exit 1
+    fi
+    if [[ ! "$target_gid" =~ ^[0-9]+$ ]]; then
+        echo "PGID must be a numeric group ID" >&2
+        exit 1
+    fi
+
+    local current_uid current_gid target_group existing_user
+    current_uid="$(id -u onesearch)"
+    current_gid="$(id -g onesearch)"
+
+    target_group="$(getent group "$target_gid" | cut -d: -f1 || true)"
+    if [ -z "$target_group" ]; then
+        if [ "$target_gid" != "$current_gid" ]; then
+            groupmod -g "$target_gid" onesearch
+        fi
+        target_group="onesearch"
+    fi
+
+    existing_user="$(getent passwd "$target_uid" | cut -d: -f1 || true)"
+    if [ -n "$existing_user" ] && [ "$existing_user" != "onesearch" ]; then
+        echo "PUID $target_uid is already used by user '$existing_user'" >&2
+        exit 1
+    fi
+
+    if [ "$target_uid" != "$current_uid" ]; then
+        usermod -u "$target_uid" onesearch
+    fi
+    usermod -g "$target_group" onesearch
+}
+
+configure_runtime_user
+
+# Ensure data directories are owned by the runtime onesearch user/group
 # (Docker volumes may be root-owned on first create or upgrades)
-chown -R onesearch:onesearch /app/data 2>/dev/null || true
+chown -R "$(id -u onesearch):$(id -g onesearch)" /app/data 2>/dev/null || true
 
 if [ "${ONESEARCH_MANAGED_MEILI:-false}" = "true" ]; then
     if [ -z "${MEILI_MASTER_KEY:-}" ]; then
@@ -18,7 +57,7 @@ if [ "${ONESEARCH_MANAGED_MEILI:-false}" = "true" ]; then
 
     echo "Managed Meilisearch enabled"
     mkdir -p /app/meili_data
-    chown -R onesearch:onesearch /app/meili_data 2>/dev/null || true
+    chown -R "$(id -u onesearch):$(id -g onesearch)" /app/meili_data 2>/dev/null || true
     export MEILI_URL="http://127.0.0.1:7700"
 fi
 


### PR DESCRIPTION
Fixes #211.

This handles a few related indexing/runtime problems from that report: Docker can now run the app services with configurable `PUID`/`PGID`, live sources no longer crash if a file disappears after scanning, Markdown with broken frontmatter still indexes the body, and nested metadata is serialized safely before sending documents to Meilisearch.

Also caught one extra container issue during smoke testing: managed Meilisearch needs to start from a writable directory after the runtime UID changes, so the generated supervisord config now runs it from `/app/meili_data`.

Verified with backend tests and a targeted smoke using group-readable source mounts, malformed Markdown, datetime frontmatter, and a file deleted during indexing.
