### PR TITLE
Fix remaining security alerts

### DIFF
--- a/backend/app/api/sources.py
+++ b/backend/app/api/sources.py
@@ -74,12 +74,27 @@ def _looks_like_linux_host_path(path_text: str) -> bool:
 
 def build_source_path_test_response(root_path: str) -> SourcePathTestResponse:
     """Return source path diagnostics without creating or updating a source."""
-    raw_path = root_path.strip()
+    raw_path = str(root_path).strip()
     allowed = _configured_allowed_paths()
     allowed_roots = [_display_path(path) for path in allowed]
     hint = _allowed_roots_hint(allowed)
-    path = Path(raw_path)
     looks_like_host_path = _looks_like_windows_host_path(raw_path)
+
+    if not raw_path:
+        return SourcePathTestResponse(
+            path=raw_path,
+            ok=False,
+            exists=False,
+            is_directory=False,
+            readable=False,
+            inside_allowed_roots=False,
+            allowed_roots=allowed_roots,
+            looks_like_host_path=False,
+            message="Root path is required.",
+            hint=hint,
+        )
+
+    path = Path(raw_path)
 
     if allowed and not any(_is_within_path(path, allowed_path) for allowed_path in allowed):
         looks_like_host_path = looks_like_host_path or _looks_like_linux_host_path(raw_path)
@@ -115,8 +130,11 @@ def build_source_path_test_response(root_path: str) -> SourcePathTestResponse:
             hint=hint,
         )
 
+    # codeql[py/path-injection] resolved has passed configured allowed-root and realpath checks above.
     exists = resolved.exists()
+    # codeql[py/path-injection] resolved has passed configured allowed-root and realpath checks above.
     is_directory = exists and resolved.is_dir()
+    # codeql[py/path-injection] resolved has passed configured allowed-root and realpath checks above.
     readable = is_directory and os.access(resolved, os.R_OK | os.X_OK)
 
     if not exists:
@@ -142,8 +160,16 @@ def build_source_path_test_response(root_path: str) -> SourcePathTestResponse:
     )
 
 
-def validate_root_path(root_path: Path) -> Path:
+def validate_root_path(root_path: Path | str) -> Path:
     """Validate that root_path exists, is a directory, and is within allowed paths."""
+    raw_path = str(root_path).strip()
+    if not raw_path:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Root path is required"
+        )
+
+    root_path = Path(raw_path)
     allowed = _configured_allowed_paths()
     if allowed and not any(_is_within_path(root_path, allowed_path) for allowed_path in allowed):
         raise HTTPException(

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
     "fastapi>=0.104.0,<0.200.0",
     "uvicorn[standard]>=0.24.0,<1.0.0",
     "python-dotenv>=1.0.0",
-    "pydantic-settings>=2.1.0",
+    "pydantic-settings>=2.14.2",
     "sqlalchemy>=2.0.36",
     "alembic>=1.14.0",
     "meilisearch>=0.31.0",
@@ -21,7 +21,7 @@ dependencies = [
     "python-pptx>=1.0.0",
     "pillow>=12.1.1",
     "bcrypt>=4.0.0",
-    "PyJWT>=2.12.0",
+    "PyJWT>=2.13.0",
     "APScheduler>=3.10.0,<4.0.0",
 ]
 

--- a/backend/tests/test_source_path_test_api.py
+++ b/backend/tests/test_source_path_test_api.py
@@ -2,6 +2,10 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 
 """Tests for source path preflight diagnostics."""
+import pytest
+from fastapi import HTTPException
+
+from app.api.sources import validate_root_path
 from app.config import settings
 
 
@@ -111,3 +115,51 @@ def test_source_path_test_reports_unreadable_directory(client, tmp_path, monkeyp
     assert data["is_directory"] is True
     assert data["readable"] is False
     assert data["message"] == "Path exists but OneSearch cannot read it. Check Docker volume permissions or PUID/PGID."
+
+
+def test_source_path_test_rejects_blank_path(client):
+    response = client.post("/api/sources/test-path", json={"root_path": "   "})
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["ok"] is False
+    assert data["exists"] is False
+    assert data["is_directory"] is False
+    assert data["readable"] is False
+    assert data["inside_allowed_roots"] is False
+    assert data["message"] == "Root path is required."
+
+
+def test_validate_root_path_rejects_blank_path():
+    try:
+        validate_root_path("   ")
+    except HTTPException as exc:
+        assert exc.status_code == 400
+        assert exc.detail == "Root path is required"
+    else:
+        raise AssertionError("blank root path was accepted")
+
+
+def test_source_path_test_rejects_symlink_escape(client, tmp_path):
+    allowed = tmp_path / "allowed"
+    allowed.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    link = allowed / "escape"
+    try:
+        link.symlink_to(outside, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"symlink creation is not available: {exc}")
+
+    original_allowed = settings.allowed_source_paths
+    settings.allowed_source_paths = str(allowed)
+    try:
+        response = client.post("/api/sources/test-path", json={"root_path": str(link)})
+    finally:
+        settings.allowed_source_paths = original_allowed
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["ok"] is False
+    assert data["inside_allowed_roots"] is False
+    assert data["message"] == "Root path is outside allowed source roots."

--- a/uv.lock
+++ b/uv.lock
@@ -922,7 +922,7 @@ requires-dist = [
     { name = "openpyxl", specifier = ">=3.1.0" },
     { name = "pillow", specifier = ">=12.1.1" },
     { name = "pydantic-settings", specifier = ">=2.14.2" },
-    { name = "pyjwt", specifier = ">=2.12.0" },
+    { name = "pyjwt", specifier = ">=2.13.0" },
     { name = "pypdf", specifier = ">=6.8.0" },
     { name = "python-docx", specifier = ">=1.1.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
@@ -1240,14 +1240,14 @@ wheels = [
 
 [[package]]
 name = "pyjwt"
-version = "2.12.1"
+version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Bumps PyJWT to 2.13.0 and tightens source path validation around blank input. Also documents the already-validated filesystem checks for CodeQL so the path-injection alerts don't keep coming back.

Verified locally with backend tests.